### PR TITLE
HU-07: Crear Cuenta Alumno (Coordinador)

### DIFF
--- a/src/app/(main)/coordinador/alumnos/actions.ts
+++ b/src/app/(main)/coordinador/alumnos/actions.ts
@@ -1,0 +1,63 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { CreateAlumnoSchema } from '@/lib/validators';
+import { AlumnoService } from '@/lib/services/alumnoService';
+import { verifyUserSession } from '@/lib/auth';
+
+interface CreateAlumnoFormState {
+  message?: string;
+  errors?: Record<string, string[]>;
+  success: boolean;
+  initialPassword?: string;
+}
+
+export async function createAlumnoAction(
+  prevState: CreateAlumnoFormState | undefined,
+  formData: FormData
+): Promise<CreateAlumnoFormState> {
+  // 1. Verificar que el usuario sea Coordinador
+  const session = await verifyUserSession();
+  if (!session || session.rol !== 'Coordinador') {
+    return {
+      message: 'No autorizado',
+      errors: { general: ['No tiene permiso para realizar esta acción.'] },
+      success: false,
+    };
+  }
+
+  // 2. Convertir FormData a objeto
+  const rawFormData = {
+    rut: formData.get('rut'),
+    nombre: formData.get('nombre'),
+    apellido: formData.get('apellido'),
+    carreraId: Number(formData.get('carreraId')),
+  };
+
+  // 3. Validar datos con Zod
+  const validatedFields = CreateAlumnoSchema.safeParse(rawFormData);
+
+  if (!validatedFields.success) {
+    console.log("Errores de validación:", validatedFields.error.flatten().fieldErrors);
+    return {
+      message: 'Error en los datos del formulario.',
+      errors: validatedFields.error.flatten().fieldErrors,
+      success: false,
+    };
+  }
+
+  // 4. Llamar al servicio de creación
+  const result = await AlumnoService.createAlumnoUser(validatedFields.data);
+
+  // 5. Si el alumno se creó exitosamente, revalidar la página
+  if (result.success) {
+    revalidatePath('/coordinador/alumnos');
+  }
+
+  return {
+    message: result.message,
+    errors: result.errors,
+    success: result.success,
+    initialPassword: result.initialPassword,
+  };
+}

--- a/src/app/(main)/coordinador/alumnos/create-alumno-dialog.tsx
+++ b/src/app/(main)/coordinador/alumnos/create-alumno-dialog.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+import { Plus } from 'lucide-react';
+import { 
+  Dialog, 
+  DialogContent, 
+  DialogDescription, 
+  DialogFooter, 
+  DialogHeader, 
+  DialogTitle, 
+  DialogTrigger 
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CreateAlumnoSchema, type CreateAlumnoFormData } from '@/lib/validators';
+import { createAlumnoAction } from './actions';
+
+type Carrera = {
+  id: number;
+  nombre: string;
+};
+
+export function CreateAlumnoDialog() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [carreras, setCarreras] = useState<readonly Carrera[]>([]);
+
+  const form = useForm<CreateAlumnoFormData>({
+    resolver: zodResolver(CreateAlumnoSchema),
+    defaultValues: {
+      rut: '',
+      nombre: '',
+      apellido: '',
+      carreraId: undefined,
+    },
+  });
+
+  useEffect(() => {
+    async function loadCarreras() {
+      try {
+        const response = await fetch('/api/carreras');
+        const data = await response.json();
+        setCarreras(data);
+      } catch (error) {
+        console.error('Error al cargar carreras:', error);
+        toast.error('Error al cargar las carreras');
+      }
+    }
+    
+    if (open) {
+      loadCarreras();
+    }
+  }, [open]);
+
+  const onSubmit = async (data: CreateAlumnoFormData) => {
+    setIsSubmitting(true);
+    try {
+      const formData = new FormData();
+      Object.entries(data).forEach(([key, value]) => {
+        formData.append(key, value.toString());
+      });
+
+      const response = await createAlumnoAction(undefined, formData);
+
+      if (response.success) {
+        toast.success(response.message);
+        if (response.initialPassword) {
+          toast.info(`Contraseña inicial: ${response.initialPassword}`, {
+            duration: 10000,
+          });
+        }
+        setOpen(false);
+        form.reset();
+        router.refresh();
+      } else {
+        if (response.errors) {
+          Object.entries(response.errors).forEach(([field, messages]) => {
+            if (field === 'general') {
+              toast.error(messages.join(' '));
+            } else {
+              form.setError(field as keyof CreateAlumnoFormData, {
+                type: 'server',
+                message: messages.join(' '),
+              });
+            }
+          });
+        } else {
+          toast.error(response.message || 'Error al crear el alumno');
+        }
+      }
+    } catch (error) {
+      console.error('Error al crear alumno:', error);
+      toast.error('Ocurrió un error inesperado');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <Plus className="mr-2 h-4 w-4" />
+          Registrar Alumno
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Registrar Nuevo Alumno</DialogTitle>
+          <DialogDescription>
+            Complete los datos para registrar un nuevo alumno en el sistema.
+            La contraseña inicial se generará automáticamente.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="rut"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>RUT</FormLabel>
+                  <FormControl>
+                    <Input placeholder="12345678-9" {...field} disabled={isSubmitting} />
+                  </FormControl>
+                  <FormDescription>
+                    RUT con guion y dígito verificador
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="nombre"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input {...field} disabled={isSubmitting} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="apellido"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Apellido</FormLabel>
+                  <FormControl>
+                    <Input {...field} disabled={isSubmitting} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="carreraId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Carrera</FormLabel>
+                  <Select
+                    value={field.value?.toString()}
+                    onValueChange={(value) => field.onChange(Number(value))}
+                    disabled={isSubmitting}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccione una carrera" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {carreras.map(carrera => (
+                        <SelectItem key={carrera.id} value={carrera.id.toString()}>
+                          {carrera.nombre}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Seleccione la carrera del alumno
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? 'Registrando...' : 'Registrar Alumno'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(main)/coordinador/alumnos/page.tsx
+++ b/src/app/(main)/coordinador/alumnos/page.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/hooks';
+import { useRouter } from 'next/navigation';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { CreateAlumnoDialog } from './create-alumno-dialog';
+import { Search } from 'lucide-react';
+
+interface Alumno {
+  id: number;
+  rut: string;
+  nombre: string;
+  apellido: string;
+  email: string;
+  carrera: {
+    nombre: string;
+  };
+}
+
+export default function AlumnosPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+  const [alumnos, setAlumnos] = useState<Alumno[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Proteger la ruta - solo Coordinador puede acceder
+  useEffect(() => {
+    if (mounted && user && user.rol !== 'Coordinador') {
+      router.push('/dashboard');
+    }
+  }, [mounted, user, router]);
+
+  // Cargar alumnos
+  useEffect(() => {
+    async function loadAlumnos() {
+      try {
+        const response = await fetch('/api/alumnos');
+        const data = await response.json();
+        setAlumnos(data);
+      } catch (error) {
+        console.error('Error al cargar alumnos:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (mounted && user?.rol === 'Coordinador') {
+      loadAlumnos();
+    }
+  }, [mounted, user]);
+
+  if (!mounted || !user || user.rol !== 'Coordinador') {
+    return null;
+  }
+
+  // Filtrar alumnos según el término de búsqueda
+  const filteredAlumnos = alumnos.filter(alumno => {
+    const searchTermLower = searchTerm.toLowerCase();
+    return (
+      alumno.rut.toLowerCase().includes(searchTermLower) ||
+      alumno.nombre.toLowerCase().includes(searchTermLower) ||
+      alumno.apellido.toLowerCase().includes(searchTermLower) ||
+      alumno.carrera.nombre.toLowerCase().includes(searchTermLower)
+    );
+  });
+
+  return (
+    <div className="container mx-auto py-6">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Gestión de Alumnos</h1>
+        <CreateAlumnoDialog />
+      </div>
+
+      <div className="relative mb-4">
+        <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Buscar alumnos..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="pl-8"
+        />
+      </div>
+
+      <div className="border rounded-md">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>RUT</TableHead>
+              <TableHead>Nombre</TableHead>
+              <TableHead>Apellido</TableHead>
+              <TableHead>Carrera</TableHead>
+              <TableHead>Email</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-4">
+                  Cargando alumnos...
+                </TableCell>
+              </TableRow>
+            ) : filteredAlumnos.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-4">
+                  No se encontraron alumnos.
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredAlumnos.map((alumno) => (
+                <TableRow key={alumno.id}>
+                  <TableCell>{alumno.rut}</TableCell>
+                  <TableCell>{alumno.nombre}</TableCell>
+                  <TableCell>{alumno.apellido}</TableCell>
+                  <TableCell>{alumno.carrera.nombre}</TableCell>
+                  <TableCell>{alumno.email}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/alumnos/route.ts
+++ b/src/app/api/alumnos/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { verifyUserSession } from '@/lib/auth';
+
+export async function GET() {
+  try {
+    // 1. Verificar autenticación
+    const user = await verifyUserSession();
+    if (!user || user.rol !== 'Coordinador') {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }    
+    type AlumnoResponse = {
+      id: number;
+      rut: string;
+      nombre: string;
+      apellido: string;
+      email: string;
+      carrera: {
+        nombre: string;
+      };
+    };
+
+    // 2. Obtener alumnos con sus relaciones
+    const alumnos = await prisma.alumno.findMany({
+      select: {
+        id: true,
+        usuario: {
+          select: {
+            rut: true,
+            nombre: true,
+            apellido: true,
+            email: true,
+          }
+        },
+        carrera: {
+          select: {
+            nombre: true,
+          }
+        }
+      },
+      orderBy: {
+        usuario: {
+          apellido: 'asc',
+        }
+      },
+    });
+
+    // 3. Transformar datos para el frontend
+    const transformedAlumnos = alumnos.map(alumno => ({
+      id: alumno.id,
+      rut: alumno.usuario.rut,
+      nombre: alumno.usuario.nombre,
+      apellido: alumno.usuario.apellido,
+      email: alumno.usuario.email,
+      carrera: alumno.carrera,
+    }));
+
+    return NextResponse.json(transformedAlumnos);
+
+  } catch (error) {
+    console.error('Error al obtener alumnos:', error);
+    return NextResponse.json(
+      { error: 'Error al obtener alumnos' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/carreras/route.ts
+++ b/src/app/api/carreras/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { verifyUserSession } from '@/lib/auth';
+
+export async function GET() {
+  try {
+    // 1. Verificar autenticación
+    const user = await verifyUserSession();
+    if (!user || user.rol !== 'Coordinador') {
+      return NextResponse.json(
+        { error: 'No autorizado' },
+        { status: 401 }
+      );
+    }
+
+    // 2. Obtener carreras activas
+    const carreras = await prisma.carrera.findMany({
+      where: {
+        estado: 'ACTIVO'
+      },
+      select: {
+        id: true,
+        nombre: true,
+      },
+      orderBy: {
+        nombre: 'asc',
+      },
+    });
+
+    return NextResponse.json(carreras);
+
+  } catch (error) {
+    console.error('Error al obtener carreras:', error);
+    return NextResponse.json(
+      { error: 'Error al obtener carreras' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/services/alumnoService.ts
+++ b/src/lib/services/alumnoService.ts
@@ -1,0 +1,119 @@
+import prisma from '@/lib/prisma';
+import { CreateAlumnoFormData } from '@/lib/validators';
+import { hashPassword } from '@/lib/auth';
+import { generateSecurePassword } from '@/lib/utils';
+
+export interface CreateAlumnoResponse {
+  success: boolean;
+  message: string;
+  errors?: Record<string, string[]>;
+  initialPassword?: string;
+}
+
+export class AlumnoService {
+  /**
+   * Crea un nuevo alumno y su cuenta de usuario asociada.
+   * @param data Los datos del alumno a crear
+   * @returns Objeto con el resultado de la operación
+   */  
+  static async createAlumnoUser(data: CreateAlumnoFormData): Promise<CreateAlumnoResponse> {
+    try {
+      // 1. Verificar que el RUT no exista como usuario alumno
+      const existingUser = await prisma.usuario.findFirst({
+        select: {
+          id: true,
+          rut: true
+        },
+        where: {
+          rut: data.rut,
+          rol: {
+            nombre: 'Alumno'
+          }
+        }
+      });
+
+      if (existingUser) {
+        return {
+          success: false,
+          message: 'Ya existe un alumno registrado con este RUT.',
+          errors: {
+            rut: ['Ya existe un alumno registrado con este RUT.']
+          }
+        };
+      }
+
+      // 2. Verificar que la carrera exista
+      const carrera = await prisma.carrera.findUnique({
+        where: { id: data.carreraId }
+      });
+
+      if (!carrera) {
+        return {
+          success: false,
+          message: 'La carrera seleccionada no existe.',
+          errors: {
+            carreraId: ['La carrera seleccionada no existe.']
+          }
+        };
+      }
+
+      // 3. Generar contraseña inicial
+      const initialPassword = generateSecurePassword();
+      const hashedPassword = await hashPassword(initialPassword);
+
+      // 4. Crear el usuario y alumno en una transacción
+      const result = await prisma.$transaction(async (tx) => {
+        // 4.1 Crear el usuario
+        const usuario = await tx.usuario.create({
+          data: {
+            rut: data.rut,
+            nombre: data.nombre,
+            apellido: data.apellido,
+            password: hashedPassword,
+            email: '', // El email se puede actualizar después
+            estado: 'ACTIVO',
+            rol: {
+              connect: {
+                nombre: 'Alumno'
+              }
+            }
+          }
+        });
+
+        // 4.2 Crear el alumno
+        await tx.alumno.create({
+          data: {
+            usuario: {
+              connect: {
+                id: usuario.id
+              }
+            },
+            carrera: {
+              connect: {
+                id: data.carreraId
+              }
+            }
+          }
+        });
+
+        return usuario;
+      });
+
+      return {
+        success: true,
+        message: 'Alumno creado exitosamente.',
+        initialPassword
+      };
+
+    } catch (error) {
+      console.error('Error al crear alumno:', error);
+      return {
+        success: false,
+        message: 'Error al crear el alumno.',
+        errors: {
+          general: ['Ha ocurrido un error inesperado. Por favor, intente de nuevo.']
+        }
+      };
+    }
+  }
+}

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,2 +1,3 @@
 export * from './userService';
 export * from './sedeService';
+export * from './alumnoService';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -32,3 +32,27 @@ export function generateInitialPassword(): string {
   
   return `${digits}${letters}`;
 }
+
+/**
+ * Genera una contraseña segura para nuevos usuarios
+ * @returns Una contraseña que cumple con los requisitos de seguridad
+ */
+export function generateSecurePassword(): string {
+  const length = 12;
+  const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*';
+  let password = '';
+  
+  // Asegurar al menos un carácter de cada tipo
+  password += 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[Math.floor(Math.random() * 26)]; // Mayúscula
+  password += 'abcdefghijklmnopqrstuvwxyz'[Math.floor(Math.random() * 26)]; // Minúscula
+  password += '0123456789'[Math.floor(Math.random() * 10)]; // Número
+  password += '!@#$%^&*'[Math.floor(Math.random() * 8)]; // Especial
+  
+  // Completar el resto de la contraseña
+  for (let i = password.length; i < length; i++) {
+    password += charset[Math.floor(Math.random() * charset.length)];
+  }
+  
+  // Mezclar todos los caracteres
+  return password.split('').sort(() => Math.random() - 0.5).join('');
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -50,6 +50,24 @@ export const UpdateUserSchema = z.object({
   }),
 });
 
+export const CreateAlumnoSchema = z.object({
+  rut: z.string()
+    .min(8, 'RUT debe tener al menos 8 caracteres')
+    .max(12, 'RUT no puede tener más de 12 caracteres')
+    .regex(/^[0-9]{7,8}-[0-9kK]$/, 'RUT debe tener el formato correcto (ej: 12345678-9)'),
+  nombre: z.string()
+    .min(2, 'Nombre debe tener al menos 2 caracteres')
+    .max(50, 'Nombre no puede tener más de 50 caracteres'),
+  apellido: z.string()
+    .min(2, 'Apellido debe tener al menos 2 caracteres')
+    .max(50, 'Apellido no puede tener más de 50 caracteres'),
+  carreraId: z.number({
+    required_error: 'Debe seleccionar una carrera',
+    invalid_type_error: 'Carrera inválida',
+  }),
+});
+
 export type LoginFormData = z.infer<typeof LoginSchema>;
 export type CreateUserFormData = z.infer<typeof CreateUserSchema>;
 export type UpdateUserFormData = z.infer<typeof UpdateUserSchema>;
+export type CreateAlumnoFormData = z.infer<typeof CreateAlumnoSchema>;


### PR DESCRIPTION
Implementación de la funcionalidad que permite a los coordinadores crear cuentas de usuario para alumnos que inician su registro de práctica.

## Cambios Principales
- Implementación del servicio `AlumnoService` para crear cuentas de alumnos
- Creación de endpoints REST para gestión de alumnos
- Desarrollo del formulario de creación con validaciones
- Implementación de página de listado con búsqueda
- Generación automática de contraseñas seguras

## Detalles Técnicos
- Validación de datos usando Zod
- Integración con el sistema de roles y permisos
- Manejo de transacciones para crear usuario y alumno
- Interfaz responsiva con Shadcn/ui
- Búsqueda en tiempo real