### PR TITLE
HU-19: Cálculo Avanzado de Fecha de Término de Práctica (con Feriados)

### DIFF
--- a/src/app/(main)/coordinador/practicas/actions.ts
+++ b/src/app/(main)/coordinador/practicas/actions.ts
@@ -5,7 +5,7 @@ import { ZodError } from 'zod';
 import { Prisma, TipoPractica as PrismaTipoPracticaEnum } from '@prisma/client';
 
 import { authorizeCoordinador } from '@/lib/auth/checkRole';
-import { PracticaService, calculateFechaTerminoSugerida } from '@/lib/services/practicaService';
+import { PracticaService } from '@/lib/services/practicaService';
 import { AlumnoService } from '@/lib/services/alumnoService';
 import { DocenteService } from '@/lib/services/docenteService';
 import { 
@@ -13,7 +13,6 @@ import {
     type IniciarPracticaInput, 
     type PracticaConDetalles 
 } from '@/lib/validators/practica';
-import prismaClient from '@/lib/prisma';
 
 // Definición de ActionResponse
 export type ActionResponse<TData = null> = {

--- a/src/lib/services/holidayService.ts
+++ b/src/lib/services/holidayService.ts
@@ -1,0 +1,93 @@
+interface ApiHoliday {
+  date: string; // "YYYY-MM-DD"
+  title: string;
+  type: string;
+  inalienable: boolean;
+  extra: string;
+}
+
+// Interfaz para la estructura de la respuesta completa de la API
+interface ApiResponse {
+  status: string;
+  data: ApiHoliday[];
+}
+
+// Caché simple en memoria para los feriados: Map<año, Set<string_fecha_YYYY-MM-DD>>
+const holidayCacheByYear = new Map<number, Set<string>>();
+const lastFetchTimestampByYear = new Map<number, number>();
+const CACHE_TTL_HOURS = 6;
+
+/**
+ * Obtiene y cachea los feriados para un año específico desde la API de Boostr.cl.
+ * @param year El año para el cual obtener los feriados.
+ * @returns Un Set con las fechas de los feriados en formato "YYYY-MM-DD".
+ */
+async function fetchAndCacheHolidaysForYear(year: number): Promise<Set<string>> {
+  const currentTime = Date.now();
+  const lastFetch = lastFetchTimestampByYear.get(year);
+
+  if (lastFetch && (currentTime - lastFetch < CACHE_TTL_HOURS * 60 * 60 * 1000)) {
+    const cachedHolidays = holidayCacheByYear.get(year);
+    if (cachedHolidays) {
+      return cachedHolidays;
+    }
+  }
+
+  console.log(`Obteniendo feriados para el año ${year} desde api.boostr.cl...`);
+  try {
+    const response = await fetch(`https://api.boostr.cl/holidays/${year}.json`, {
+      method: 'GET',
+      headers: {
+        'accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      // Intenta obtener más detalles del error si la API los provee
+      let errorDetails = `Error HTTP ${response.status}: ${response.statusText}`;
+      try {
+        const errorBody = await response.json();
+        errorDetails += ` - ${JSON.stringify(errorBody)}`;
+      } catch (e) { /* No se pudo parsear el cuerpo del error, se ignora */ }
+      
+      console.error(`Error al obtener feriados para el año ${year}: ${errorDetails}`);
+      // Devuelve el caché antiguo si existe, o un set vacío para no bloquear el cálculo principal
+      return holidayCacheByYear.get(year) || new Set<string>();
+    }
+
+    const responseData: ApiResponse = await response.json();
+
+    if (responseData && responseData.status === 'success' && Array.isArray(responseData.data)) {
+      const holidaysForYear = new Set(
+        responseData.data.map((holiday: ApiHoliday) => holiday.date) // Solo nos interesan las fechas "YYYY-MM-DD"
+      );
+      holidayCacheByYear.set(year, holidaysForYear);
+      lastFetchTimestampByYear.set(year, currentTime);
+      return holidaysForYear;
+    } else {
+      console.error(`Estructura de respuesta inesperada de la API de feriados para el año ${year}:`, responseData);
+      return holidayCacheByYear.get(year) || new Set<string>();
+    }
+  } catch (error) {
+    console.error(`Error de red u otro al obtener feriados para el año ${year}:`, error);
+    return holidayCacheByYear.get(year) || new Set<string>();
+  }
+}
+
+
+/**
+ * Verifica si una fecha dada es un feriado.
+ * Utiliza el caché y consulta la API si es necesario.
+ */
+export async function isHoliday(fecha: Date): Promise<boolean> {
+  const year = fecha.getUTCFullYear();
+  // La función fetchAndCacheHolidaysForYear maneja el caché y la obtención por año.
+  const holidaysInYear = await fetchAndCacheHolidaysForYear(year);
+
+  // Formatea la fecha de entrada a YYYY-MM-DD en UTC para una comparación consistente.
+  const month = (fecha.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = fecha.getUTCDate().toString().padStart(2, '0');
+  const fechaStr = `${year}-${month}-${day}`;
+  
+  return holidaysInYear.has(fechaStr);
+}

--- a/src/lib/services/holidayService.ts
+++ b/src/lib/services/holidayService.ts
@@ -48,7 +48,10 @@ async function fetchAndCacheHolidaysForYear(year: number): Promise<Set<string>> 
       try {
         const errorBody = await response.json();
         errorDetails += ` - ${JSON.stringify(errorBody)}`;
-      } catch (e) { /* No se pudo parsear el cuerpo del error, se ignora */ }
+      } catch ( jsonError) {
+        // Si no se puede parsear el cuerpo de error, manten el mensaje original
+        console.warn(`No se pudo parsear el cuerpo del error: ${jsonError}`);
+      }
       
       console.error(`Error al obtener feriados para el año ${year}: ${errorDetails}`);
       // Devuelve el caché antiguo si existe, o un set vacío para no bloquear el cálculo principal

--- a/src/lib/services/practicaService.ts
+++ b/src/lib/services/practicaService.ts
@@ -27,8 +27,8 @@ export async function calculateFechaTerminoSugerida(
     throw new Error("Las horas de práctica requeridas deben ser un número positivo.");
   }
 
-  let diasLaboralesNecesarios = Math.ceil(horasPracticaRequeridas / HORAS_POR_DIA_LABORAL);
-  let fechaActual = new Date(fechaInicio.valueOf());
+  const diasLaboralesNecesarios = Math.ceil(horasPracticaRequeridas / HORAS_POR_DIA_LABORAL);
+  const fechaActual = new Date(fechaInicio.valueOf());
   let diasLaboralesContados = 0;
   let iteracionesSeguridad = 0;
   const MAX_ITERACIONES = diasLaboralesNecesarios + 365 * 2; // Margen para feriados en 2 años
@@ -76,7 +76,7 @@ export class PracticaService {
         return { success: false, error: 'Carrera no encontrada para calcular horas.' };
       }
 
-     let horasRequeridas = tipoPractica === PrismaTipoPracticaEnum.LABORAL 
+     const horasRequeridas = tipoPractica === PrismaTipoPracticaEnum.LABORAL 
         ? carrera.horasPracticaLaboral 
         : carrera.horasPracticaProfesional;
 
@@ -87,7 +87,7 @@ export class PracticaService {
         };
       }
 
-      const fechaTerminoSugerida = await calculateFechaTerminoSugerida(fechaInicio, horasRequeridas); // <--- await
+      const fechaTerminoSugerida = await calculateFechaTerminoSugerida(fechaInicio, horasRequeridas);
       return { success: true, data: fechaTerminoSugerida };
 
     } catch (error) {

--- a/src/lib/services/practicaService.ts
+++ b/src/lib/services/practicaService.ts
@@ -5,6 +5,8 @@ import {
     EstadoPractica as PrismaEstadoPracticaEnum,
     Prisma 
 } from '@prisma/client';
+import { isHoliday } from './holidayService';
+
 
 const HORAS_POR_DIA_LABORAL = 8; // Asunción: 8 horas por día laboral
 
@@ -16,49 +18,55 @@ const HORAS_POR_DIA_LABORAL = 8; // Asunción: 8 horas por día laboral
  * @returns La fecha de término calculada.
  * @throws Error si las horas de práctica son 0 o negativas.
  */
-export function calculateFechaTerminoSugerida(fechaInicio: Date, horasPracticaRequeridas: number): Date {
+export async function calculateFechaTerminoSugerida(
+  fechaInicio: Date,
+  horasPracticaRequeridas: number
+): Promise<Date> {
+  
   if (horasPracticaRequeridas <= 0) {
     throw new Error("Las horas de práctica requeridas deben ser un número positivo.");
   }
 
   let diasLaboralesNecesarios = Math.ceil(horasPracticaRequeridas / HORAS_POR_DIA_LABORAL);
-  const fechaTermino = new Date(fechaInicio.valueOf());
-  let diasAgregados = 0;
+  let fechaActual = new Date(fechaInicio.valueOf());
+  let diasLaboralesContados = 0;
+  let iteracionesSeguridad = 0;
+  const MAX_ITERACIONES = diasLaboralesNecesarios + 365 * 2; // Margen para feriados en 2 años
 
-  // Si el día de inicio es fin de semana, lo movemos al siguiente lunes (o al mismo día si es laboral)
-  // para asegurar que el conteo empiece en un día laboral o el cálculo sea correcto.
-  // Asumimos que el coordinador elige una fecha de inicio laboral, o el cálculo es "bruto".
-  // Para un cálculo más preciso, se necesitaría una librería de manejo de fechas laborales.
-
-  // Si el primer día es laboral y se cuentan las horas de ese día:
-  const diaInicioSemana = fechaInicio.getDay();
-  if (diaInicioSemana !== 0 && diaInicioSemana !== 6) { // Si el día de inicio es laboral
-      diasLaboralesNecesarios--; // Ya cuenta como un día trabajado
-  }
-
-
-  while (diasAgregados < diasLaboralesNecesarios) {
-    fechaTermino.setDate(fechaTermino.getDate() + 1);
-    const diaDeLaSemana = fechaTermino.getDay();
-    if (diaDeLaSemana !== 0 && diaDeLaSemana !== 6) { // No es Domingo ni Sábado
-      diasAgregados++;
+  while (diasLaboralesContados < diasLaboralesNecesarios && iteracionesSeguridad < MAX_ITERACIONES) {
+    const diaDeLaSemana = fechaActual.getDay();
+    
+    if (diaDeLaSemana !== 0 && diaDeLaSemana !== 6 && !(await isHoliday(fechaActual))) { // <--- await isHoliday
+      diasLaboralesContados++;
     }
+    
+    if (diasLaboralesContados < diasLaboralesNecesarios) {
+      fechaActual.setDate(fechaActual.getDate() + 1);
+    }
+    iteracionesSeguridad++;
   }
-  return fechaTermino;
+
+  if (iteracionesSeguridad >= MAX_ITERACIONES) {
+      console.warn("Cálculo de fecha de término excedió iteraciones de seguridad.");
+      throw new Error("No se pudo calcular una fecha de término dentro de un rango razonable (posiblemente demasiados feriados o error en API).");
+  }
+
+  return fechaActual;
 }
 
 export class PracticaService {
+
   /**
    * Sugiere una fecha de término para una práctica.
    * @param fechaInicio La fecha de inicio propuesta.
    * @param tipoPractica El tipo de práctica (LABORAL o PROFESIONAL).
    * @param carreraId El ID de la carrera para obtener las horas requeridas.
    */
-  static async sugerirFechaTermino(
+   static async sugerirFechaTermino(
     fechaInicio: Date,
     tipoPractica: PrismaTipoPracticaEnum,
     carreraId: number
-  ) {
+  ): Promise<{ success: boolean; data?: Date; error?: string }> {
     try {
       const carrera = await prisma.carrera.findUnique({
         where: { id: carreraId },
@@ -68,14 +76,9 @@ export class PracticaService {
         return { success: false, error: 'Carrera no encontrada para calcular horas.' };
       }
 
-      let horasRequeridas: number;
-      if (tipoPractica === PrismaTipoPracticaEnum.LABORAL) {
-        horasRequeridas = carrera.horasPracticaLaboral;
-      } else if (tipoPractica === PrismaTipoPracticaEnum.PROFESIONAL) {
-        horasRequeridas = carrera.horasPracticaProfesional;
-      } else {
-        return { success: false, error: 'Tipo de práctica inválido.' };
-      }
+     let horasRequeridas = tipoPractica === PrismaTipoPracticaEnum.LABORAL 
+        ? carrera.horasPracticaLaboral 
+        : carrera.horasPracticaProfesional;
 
       if (horasRequeridas <= 0) {
         return { 
@@ -84,7 +87,7 @@ export class PracticaService {
         };
       }
 
-      const fechaTerminoSugerida = calculateFechaTerminoSugerida(fechaInicio, horasRequeridas);
+      const fechaTerminoSugerida = await calculateFechaTerminoSugerida(fechaInicio, horasRequeridas); // <--- await
       return { success: true, data: fechaTerminoSugerida };
 
     } catch (error) {


### PR DESCRIPTION
Este Pull Request refina y completa la funcionalidad de cálculo para la "Fecha de Término Sugerida" de las prácticas. La mejora principal es la **exclusión de feriados chilenos** en dicho cálculo, además de los fines de semana. Esto se logra integrando una API externa de feriados (`api.boostr.cl`) y actualizando la lógica de cálculo en el backend. La interfaz de usuario para mostrar y permitir la modificación de esta fecha ya fue implementada en HU-18.

## Cambios Implementados:

### Backend:
* **Nuevo Servicio de Feriados (`src/lib/services/holidayService.ts`):**
    * Se creó un nuevo servicio para obtener los feriados de Chile para un año específico.
    * Utiliza `Workspace` para consumir el endpoint `https://api.boostr.cl/holidays/{year}.json`.
    * Implementa un sistema de caché en memoria simple para los feriados (por año, con un TTL de 6 horas) para minimizar las llamadas a la API externa.
    * Provee una función asíncrona `isHoliday(fecha: Date)` que verifica si una fecha dada es feriado consultando los datos obtenidos.
* **Servicio de Prácticas (`src/lib/services/practicaService.ts`):**
    * La función `calculateFechaTerminoSugerida