### PR TITLE
HU-23 - Docente Revisa y Decide Supervisión de Práctica (Acta 1)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'https://fvps2orw9wsxqvtc.public.blob.vercel-storage.com',
+        port: '',
+        pathname: '/**', 
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@tanstack/react-table": "^8.21.3",
+        "@vercel/blob": "^1.1.1",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -329,6 +330,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2898,6 +2908,22 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-1.1.1.tgz",
+      "integrity": "sha512-heiJGj2qt5qTv6yiShH9f6KRAoZGj+lz61GQ+lBRL4lhvUmKI9A51KYlQTnsUd9ymdFlKHBlvmPeG+yGz2Qsbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -3176,6 +3202,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -4910,6 +4945,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -5054,6 +5112,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6738,6 +6802,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7338,6 +7411,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -7589,6 +7674,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@tanstack/react-table": "^8.21.3",
+    "@vercel/blob": "^1.1.1",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/prisma/migrations/20250528011648_add_motivo_rechazo_docente_practica/migration.sql
+++ b/prisma/migrations/20250528011648_add_motivo_rechazo_docente_practica/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Practica" ADD COLUMN     "motivoRechazoDocente" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Practica {
   tareasPrincipales    String?        @db.Text
   
   fechaCompletadoAlumno DateTime?     
+  motivoRechazoDocente String? 
   
   // Otros campos
   informeUrl           String?        
@@ -227,14 +228,14 @@ enum TipoPractica {
 }
 
 enum EstadoPractica {
-  PENDIENTE                   // Iniciada por Coord, pendiente que Alumno complete
+  PENDIENTE                     // Iniciada por Coord, pendiente que Alumno complete
   PENDIENTE_ACEPTACION_DOCENTE  // Alumno completó, Docente Tutor debe revisar/aceptar
-  EN_CURSO                    // Docente aceptó/validó, práctica en desarrollo
-  FINALIZADA_PENDIENTE_EVAL   // Práctica terminada, informes/evaluaciones pendientes
-  EVALUACION_COMPLETA         // Todas las evaluaciones completadas
-  CERRADA                     // Proceso de práctica administrativamente cerrado (nota final asignada)
-  ANULADA                     // Práctica anulada
-  RECHAZADA_DOCENTE           // Acta 1 rechazada por el docente (requiere acción del coord/alumno)
+  RECHAZADA_DOCENTE             // Docente rechazó el Acta 1
+  EN_CURSO                      // Docente aceptó/validó, práctica en desarrollo
+  FINALIZADA_PENDIENTE_EVAL     // Práctica terminada, informes/evaluaciones pendientes
+  EVALUACION_COMPLETA           // Todas las evaluaciones completadas
+  CERRADA                       // Proceso de práctica administrativamente cerrado (nota final asignada)
+  ANULADA                       // Práctica anulada
 }
 
 enum EstadoActaFinal {

--- a/src/app/(main)/alumno/mis-practicas/[practicaId]/completar-acta/completar-acta-alumno-form.tsx
+++ b/src/app/(main)/alumno/mis-practicas/[practicaId]/completar-acta/completar-acta-alumno-form.tsx
@@ -1,40 +1,99 @@
 "use client";
 
 import React from "react";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { z } from "zod";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage, FormDescription } from "@/components/ui/form";
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardFooter, 
+    CardHeader, 
+    CardTitle 
+} from "@/components/ui/card";
+import { 
+    Form, 
+    FormControl, 
+    FormDescription, 
+    FormField, 
+    FormItem, 
+    FormLabel, 
+    FormMessage 
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
-import { Link, Save, UserCircle2 } from "lucide-react";
+import { 
+    ExternalLink, 
+    Save, 
+    UserCircle2, 
+    UploadCloud, 
+    Trash2, 
+    Settings, 
+    CalendarDays, 
+    ClipboardList,
+    User as UserIcon // Renombrado para evitar conflicto con el hook User
+} from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
+import { cn } from "@/lib/utils";
 
 import { 
-    CompletarActaAlumnoData,
     completarActaAlumnoSchema, 
+    type CompletarActaAlumnoData,
     type PracticaConDetalles 
 } from "@/lib/validators/practica";
-import { submitActaAlumnoAction, type ActionResponse } from "../../../practicas/actions";
-import { TipoPractica as PrismaTipoPracticaEnum, EstadoPractica as PrismaEstadoPracticaEnum } from "@prisma/client";
-import router from "next/router";
+// Asegúrate que la ruta a actions sea correcta desde este archivo
 
+import { TipoPractica as PrismaTipoPracticaEnum, EstadoPractica as PrismaEstadoPracticaEnum } from "@prisma/client";
+import { ActionResponse, submitActaAlumnoAction } from "../../../practicas/actions";
+
+// Constantes para validación de la foto de perfil
+const MAX_FILE_SIZE_KB_FOTO_PERFIL = 256;
+const MAX_FILE_SIZE_BYTES_FOTO_PERFIL = MAX_FILE_SIZE_KB_FOTO_PERFIL * 1024;
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif'];
+const ALLOWED_IMAGE_EXTENSIONS_STRING = "JPG, PNG, GIF";
 
 interface CompletarActaAlumnoFormProps {
   practica: PracticaConDetalles & { fueraDePlazo?: boolean };
 }
 
-// Este es el tipo de datos que el formulario manejará, basado en el schema Zod
 type FormInputValues = z.input<typeof completarActaAlumnoSchema>;
 
+const InfoItem: React.FC<{ label: string; value?: string | number | boolean | null | Date; isDate?: boolean; isBoolean?: boolean; isList?: boolean;}> = ({ label, value, isDate, isBoolean, isList }) => {
+  let displayValue: React.ReactNode;
+  if (value === null || value === undefined || (typeof value === 'string' && value.trim() === '')) {
+    displayValue = <span className="text-muted-foreground italic">No provisto</span>;
+  } else if (isDate && value instanceof Date) {
+    displayValue = format(new Date(value), "PPP", { locale: es });
+  } else if (isBoolean) {
+    displayValue = value ? 'Sí' : 'No';
+  } else if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+    displayValue = <a href={value} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">{value} <ExternalLink className="inline h-3 w-3 ml-1"/></a>;
+  } else if (isList && typeof value === 'string') {
+    displayValue = <div className="whitespace-pre-wrap">{value}</div>;
+  } else {
+    displayValue = value.toString();
+  }
+  return ( <div className="py-2"> <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{label}</dt> <dd className="mt-1 text-sm text-foreground">{displayValue}</dd> </div> );
+};
+
 export function CompletarActaAlumnoForm({ practica }: CompletarActaAlumnoFormProps) {
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const routerNav = useRouter(); // Renombrado para evitar conflicto con props
+  const [isSubmitting, setIsSubmitting] = React.useState(false); // Para el submit del formulario principal del Acta 1
   const formDisabled = practica.fueraDePlazo || practica.estado !== PrismaEstadoPracticaEnum.PENDIENTE;
+
+  // Estados para la foto de perfil
+  const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = React.useState<string | null>(practica.alumno?.fotoUrl || null);
+  const [fileError, setFileError] = React.useState<string | null>(null);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  // const [isUploadingPhoto, setIsUploadingPhoto] = React.useState(false);
 
   const form = useForm<FormInputValues, unknown, CompletarActaAlumnoData>({
     resolver: zodResolver(completarActaAlumnoSchema),
@@ -45,11 +104,60 @@ export function CompletarActaAlumnoForm({ practica }: CompletarActaAlumnoFormPro
       cargoJefeDirecto: practica.cargoJefeDirecto || "",
       contactoCorreoJefe: practica.contactoCorreoJefe || "",
       contactoTelefonoJefe: practica.contactoTelefonoJefe || "",
-      practicaDistancia: practica.practicaDistancia || false,
+      practicaDistancia: practica.practicaDistancia ?? false,
       tareasPrincipales: practica.tareasPrincipales || "",
     },
     disabled: formDisabled,
   });
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFileError(null); // Limpiar errores previos
+    const file = event.target.files?.[0];
+
+    if (fileInputRef.current) {
+        fileInputRef.current.value = ""; // Permite reseleccionar el mismo archivo
+    }
+
+    if (file) {
+      if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+        const errorMsg = `Tipo de archivo no válido. Permitidos: ${ALLOWED_IMAGE_EXTENSIONS_STRING}.`;
+        toast.error(errorMsg);
+        setFileError(errorMsg);
+        setSelectedFile(null);
+        // No revertir previewUrl aquí para que el usuario vea el error
+        return;
+      }
+
+      if (file.size > MAX_FILE_SIZE_BYTES_FOTO_PERFIL) {
+        const errorMsg = `El archivo excede ${MAX_FILE_SIZE_KB_FOTO_PERFIL} KB. (Actual: ${(file.size / 1024).toFixed(1)} KB)`;
+        toast.error(errorMsg);
+        setFileError(errorMsg);
+        setSelectedFile(null);
+        return;
+      }
+
+      // Si hay una URL de preview anterior (blob), revocarla
+      if (previewUrl && previewUrl.startsWith('blob:')) {
+        URL.revokeObjectURL(previewUrl);
+      }
+
+      setSelectedFile(file);
+      const newPreviewUrl = URL.createObjectURL(file);
+      setPreviewUrl(newPreviewUrl);
+    }
+  };
+
+  const handleRemoveSelectedFile = () => {
+    if (previewUrl && previewUrl.startsWith('blob:')) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setSelectedFile(null);
+    setPreviewUrl(practica.alumno?.fotoUrl || null); // Volver a la foto guardada o a nada
+    setFileError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
 
   const onSubmitActa: SubmitHandler<CompletarActaAlumnoData> = async (data) => {
     if (formDisabled) {
@@ -59,32 +167,25 @@ export function CompletarActaAlumnoForm({ practica }: CompletarActaAlumnoFormPro
     setIsSubmitting(true);
     
     try {
+      // El envío de la foto se añadira luego
+
+      // Aquí solo enviamos los datos del Acta 1.
       const result: ActionResponse<PracticaConDetalles> = await submitActaAlumnoAction(practica.id, data);
 
       if (result.success && result.data) {
         toast.success(result.message || "Acta 1 completada y enviada para validación del docente.");
-        // Deshabilitar el formulario permanentemente después de un envío exitoso aquí.
-        form.reset(data, { keepValues: true });
-        // Redireccionar al usuario a "Mis Prácticas"
-        router.push('/alumno/mis-practicas');
+        routerNav.push('/alumno/mis-practicas');
       } else {
         if (result.errors && result.errors.length > 0) {
           result.errors.forEach(err => {
             const fieldName = Array.isArray(err.field) ? err.field.join('.') : err.field.toString();
             if (Object.prototype.hasOwnProperty.call(form.getValues(), fieldName)) {
-                 form.setError(fieldName as keyof FormInputValues, {
-                    type: "server",
-                    message: err.message,
-                 });
-            } else {
-                 toast.error(`Error: ${err.message}`);
-            }
+                 form.setError(fieldName as keyof FormInputValues, { type: "server", message: err.message });
+            } else { toast.error(`Error: ${err.message}`); }
           });
           if (Object.keys(form.formState.errors).length > 0) {
               toast.warning("Por favor corrige los errores en el formulario.");
-          } else if(result.error) { // Si no hay errores de campo pero sí un error general del servidor
-              toast.error(result.error);
-          }
+          } else if(result.error) { toast.error(result.error); }
         } else if (result.error) {
           toast.error(result.error || "No se pudo guardar la información del acta.");
         } else {
@@ -98,158 +199,131 @@ export function CompletarActaAlumnoForm({ practica }: CompletarActaAlumnoFormPro
       setIsSubmitting(false);
     }
   };
+  
+  // Limpieza del Object URL cuando el componente se desmonta o el previewUrl cambia
+  React.useEffect(() => {
+    const currentPreview = previewUrl;
+    return () => {
+      if (currentPreview && currentPreview.startsWith('blob:')) {
+        URL.revokeObjectURL(currentPreview);
+      }
+    };
+  }, [previewUrl]);
+
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmitActa)}>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4 mb-6">
-          {/* Sección Datos Pre-llenados por Coordinador (No Editables) */}
-          <Card className="md:col-span-2 shadow">
-            <CardHeader>
-              <CardTitle className="text-lg">Información Registrada por Coordinación</CardTitle>
-              <CardDescription>Estos datos son informativos y no pueden ser modificados por el alumno.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
-                <p><strong>Tipo de Práctica:</strong> {practica.tipo === PrismaTipoPracticaEnum.LABORAL ? "Laboral" : "Profesional"}</p>
-                <p><strong>Carrera:</strong> {practica.carrera?.nombre || 'N/A'}</p>
-                <p><strong>Fecha de Inicio:</strong> {format(new Date(practica.fechaInicio), "PPP", { locale: es })}</p>
-                <p><strong>Fecha de Término:</strong> {format(new Date(practica.fechaTermino), "PPP", { locale: es })}</p>
-                <p className="sm:col-span-2"><strong>Docente Tutor:</strong> {practica.docente?.usuario.nombre} {practica.docente?.usuario.apellido}</p>
-              </div>
-            </CardContent>
-          </Card>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-x-8 gap-y-6 mb-6">
+          <div className="md:col-span-1 space-y-6">
+            <Card className="shadow">
+              <CardHeader><CardTitle className="text-lg">Datos del Alumno</CardTitle></CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <InfoItem label="Nombre Completo" value={`${practica.alumno?.usuario.nombre} ${practica.alumno?.usuario.apellido}`} />
+                <InfoItem label="RUT" value={practica.alumno?.usuario.rut} />
+                <InfoItem label="Carrera" value={practica.carrera?.nombre} />
+                <InfoItem label="Sede de Carrera" value={practica.carrera?.sede?.nombre} />
+              </CardContent>
+            </Card>
+            <Card className="shadow">
+              <CardHeader><CardTitle className="text-lg">Datos de Práctica (Coordinación)</CardTitle></CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <InfoItem label="Tipo de Práctica" value={practica.tipo === PrismaTipoPracticaEnum.LABORAL ? "Laboral" : "Profesional"} />
+                <InfoItem label="Fecha de Inicio" value={practica.fechaInicio} isDate />
+                <InfoItem label="Fecha de Término" value={practica.fechaTermino} isDate />
+                <InfoItem label="Docente Tutor" value={`${practica.docente?.usuario.nombre} ${practica.docente?.usuario.apellido}`} />
+              </CardContent>
+            </Card>
+          </div>
 
-          {/* Sección Datos a Completar por Alumno */}
-          <Card className="md:col-span-2 shadow">
-            <CardHeader>
-              <CardTitle className="text-lg">Información del Centro de Práctica y Tareas</CardTitle>
-              <CardDescription>Por favor, completa los siguientes campos requeridos.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <FormField
-                control={form.control}
-                name="direccionCentro"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Dirección del Centro de Práctica <span className="text-red-500">*</span></FormLabel>
-                    <FormControl><Input placeholder="Ej: Av. Principal 123, Ciudad" {...field} /></FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="departamento"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Departamento donde realizará la práctica</FormLabel>
-                    <FormControl><Input placeholder="Ej: Área de Desarrollo de Software" {...field} /></FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="nombreJefeDirecto"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Nombre Jefe Directo <span className="text-red-500">*</span></FormLabel>
-                      <FormControl><Input placeholder="Ej: Juan Pérez" {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="cargoJefeDirecto"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Cargo Jefe Directo <span className="text-red-500">*</span></FormLabel>
-                      <FormControl><Input placeholder="Ej: Gerente de Proyectos" {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="contactoCorreoJefe"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email Jefe Directo <span className="text-red-500">*</span></FormLabel>
-                      <FormControl><Input type="email" placeholder="Ej: juan.perez@empresa.com" {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="contactoTelefonoJefe"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Teléfono Jefe Directo</FormLabel>
-                      <FormControl><Input placeholder="Ej: +56912345678" {...field} /></FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <FormField
-                control={form.control}
-                name="practicaDistancia"
-                render={({ field }) => (
-                  <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm mt-4">
-                    <div className="space-y-0.5">
-                      <FormLabel>¿La práctica es a distancia?</FormLabel>
-                      <FormDescription>
-                        Marca esta opción si tu práctica se realizará de forma remota.
-                      </FormDescription>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                        disabled={formDisabled}
+          <div className="md:col-span-2">
+            <Card className="shadow">
+              <CardHeader>
+                <CardTitle className="text-lg">Información del Centro de Práctica y Tareas</CardTitle>
+                <CardDescription>Por favor, completa los siguientes campos requeridos.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6"> {/* Aumentado space-y para más separación */}
+                {/* Sección Foto de Perfil */}
+                <FormItem>
+                  <FormLabel>Foto de Perfil</FormLabel>
+                  <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6 p-4 border rounded-lg bg-background">
+                    {previewUrl ? (
+                      <Image
+                        src={previewUrl}
+                        alt="Vista previa de foto de perfil"
+                        width={80}
+                        height={80}
+                        className="rounded-full object-cover h-20 w-20 border bg-muted"
+                        onError={() => {
+                          setPreviewUrl(null); 
+                          toast.error("No se pudo cargar la imagen de perfil actual.");
+                        }}
                       />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="tareasPrincipales"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Principales Tareas a Desempeñar <span className="text-red-500">*</span></FormLabel>
-                    <FormControl><Textarea placeholder="Describe las principales funciones y responsabilidades que tendrás..." className="min-h-[100px]" {...field} /></FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <div className="space-y-2 pt-2">
-                <FormLabel>Foto de Perfil del Alumno</FormLabel>
-                <div className="flex items-center gap-4 p-3 border rounded-md bg-muted/30">
-                  <UserCircle2 className="h-16 w-16 text-gray-400 dark:text-gray-600" />
-                  <div className="text-sm text-muted-foreground">
-                    <p>La funcionalidad para cargar o actualizar tu foto de perfil se implementará en la HU-30.</p>
-                    <p>Tu foto actual (si existe) se puede ver en tu perfil general.</p>
-                    {practica.alumno?.fotoUrl && (
-                       <p className="mt-1 text-xs">Foto actual: <Link href={practica.alumno.fotoUrl} target="_blank" className="text-blue-500 hover:underline">ver imagen</Link></p>
+                    ) : (
+                      <UserCircle2 className="h-20 w-20 text-gray-300 dark:text-gray-600 border rounded-full p-1 bg-muted" />
                     )}
+                    <div className="flex-grow space-y-2">
+                      <input
+                        type="file"
+                        ref={fileInputRef}
+                        className="hidden"
+                        accept={ALLOWED_IMAGE_TYPES.join(",")}
+                        onChange={handleFileChange}
+                        disabled={formDisabled || isSubmitting}
+                      />
+                      <div className="flex flex-col sm:flex-row gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => fileInputRef.current?.click()}
+                          disabled={formDisabled || isSubmitting}
+                        >
+                          <UploadCloud className="mr-2 h-4 w-4" />
+                          {selectedFile ? "Cambiar Foto" : "Seleccionar Foto"}
+                        </Button>
+                        {selectedFile && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={handleRemoveSelectedFile}
+                            disabled={formDisabled || isSubmitting}
+                            className="text-xs text-muted-foreground hover:text-destructive"
+                          >
+                            <Trash2 className="mr-1 h-3 w-3" /> Quitar selección
+                          </Button>
+                        )}
+                      </div>
+                       <FormDescription className="text-xs">
+                        {ALLOWED_IMAGE_EXTENSIONS_STRING}. Máx {MAX_FILE_SIZE_KB_FOTO_PERFIL}KB.
+                      </FormDescription>
+                      {fileError && <p className="text-xs text-destructive mt-1">{fileError}</p>}
+                       {/* El botón de SUBIR FOTO se conectará despues*/}
+                      <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">La subida de la foto se activará en un próximo paso (HU-30.4).</p>
+                    </div>
                   </div>
+                </FormItem>
+                
+                {/* Campos del formulario del alumno */}
+                <FormField control={form.control} name="direccionCentro" render={({ field }) => ( <FormItem> <FormLabel>Dirección del Centro de Práctica <span className="text-red-500">*</span></FormLabel> <FormControl><Input placeholder="Ej: Av. Principal 123, Ciudad" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
+                <FormField control={form.control} name="departamento" render={({ field }) => ( <FormItem> <FormLabel>Departamento</FormLabel> <FormControl><Input placeholder="Ej: Área de Desarrollo" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField control={form.control} name="nombreJefeDirecto" render={({ field }) => ( <FormItem> <FormLabel>Nombre Jefe Directo <span className="text-red-500">*</span></FormLabel> <FormControl><Input placeholder="Ej: Juan Pérez" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
+                  <FormField control={form.control} name="cargoJefeDirecto" render={({ field }) => ( <FormItem> <FormLabel>Cargo Jefe Directo <span className="text-red-500">*</span></FormLabel> <FormControl><Input placeholder="Ej: Gerente de Proyectos" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
                 </div>
-                <FormDescription>
-                  Este es un marcador de posición para la carga de la foto de perfil.
-                </FormDescription>
-              </div>
-            </CardContent>
-          </Card>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField control={form.control} name="contactoCorreoJefe" render={({ field }) => ( <FormItem> <FormLabel>Email Jefe Directo <span className="text-red-500">*</span></FormLabel> <FormControl><Input type="email" placeholder="Ej: juan.perez@empresa.com" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
+                  <FormField control={form.control} name="contactoTelefonoJefe" render={({ field }) => ( <FormItem> <FormLabel>Teléfono Jefe Directo</FormLabel> <FormControl><Input placeholder="Ej: +56912345678" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
+                </div>
+                <FormField control={form.control} name="practicaDistancia" render={({ field }) => ( <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm mt-4"> <div className="space-y-0.5"> <FormLabel>¿Práctica a distancia?</FormLabel> <FormDescription>Marca si tu práctica es remota.</FormDescription> </div> <FormControl> <Switch checked={field.value ?? false} onCheckedChange={field.onChange} /> </FormControl> </FormItem> )}/>
+                <FormField control={form.control} name="tareasPrincipales" render={({ field }) => ( <FormItem> <FormLabel>Principales Tareas a Desempeñar <span className="text-red-500">*</span></FormLabel> <FormControl><Textarea placeholder="Describe las principales funciones y responsabilidades que tendrás..." className="min-h-[100px]" {...field} /></FormControl> <FormMessage /> </FormItem> )}/>
+              </CardContent>
+            </Card>
+          </div>
         </div>
         
-        <CardFooter className="flex justify-end mt-8 border-t pt-6">
+        <CardFooter className="flex justify-end mt-6 border-t pt-6">
           <Button type="submit" disabled={isSubmitting || formDisabled}>
             <Save className="mr-2 h-4 w-4" />
             {isSubmitting ? "Guardando Acta..." : "Guardar y Enviar Acta 1"}

--- a/src/app/(main)/alumno/mis-practicas/[practicaId]/completar-acta/completar-acta-alumno-form.tsx
+++ b/src/app/(main)/alumno/mis-practicas/[practicaId]/completar-acta/completar-acta-alumno-form.tsx
@@ -146,7 +146,7 @@ export function CompletarActaAlumnoForm({ practica: initialPractica }: Completar
     formData.append("file", selectedFile);
 
     try {
-      const uploadResponse = await fetch('/api/upload', { // Llama a tu API Route
+      const uploadResponse = await fetch('/api/upload', {
         method: 'POST',
         body: formData,
       });
@@ -266,21 +266,28 @@ export function CompletarActaAlumnoForm({ practica: initialPractica }: Completar
                   <FormLabel>Actualizar Foto de Perfil</FormLabel>
                   <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-6 p-4 border rounded-lg bg-background">
                     {previewUrl ? (
-                      <Image
-                        src={previewUrl}
-                        alt="Vista previa de foto de perfil"
-                        width={80}
-                        height={80}
-                        className="rounded-full object-cover h-20 w-20 border bg-muted"
+                      <Image 
+                        src={previewUrl} 
+                        alt="Vista previa de foto de perfil" 
+                        width={80} 
+                        height={80} 
+                        className="rounded-full object-cover h-20 w-20 border bg-muted" 
                         onError={() => {
-                          setPreviewUrl(null); 
-                          toast.error("No se pudo cargar la imagen de perfil actual.");
+                            // Si la URL está rota, intenta volver al placeholder
+                            // y si era un blob, ya se habrá revocado o se limpiará.
+                            if (previewUrl !== practica.alumno?.fotoUrl) { // si era un blob y falló
+                                setPreviewUrl(practica.alumno?.fotoUrl || null);
+                            } else { // si la fotoUrl de la BD falló
+                                setPreviewUrl(null);
+                            }
+                            if (selectedFile) toast.error("El archivo seleccionado no se puede previsualizar.");
+                            else toast.error("No se pudo cargar la imagen de perfil actual.");
                         }}
                       />
                     ) : (
                       <UserCircle2 className="h-20 w-20 text-gray-300 dark:text-gray-600 border rounded-full p-1 bg-muted" />
                     )}
-                    <div className="flex-grow space-y-2">
+                     <div className="flex-grow space-y-2">
                       <input
                         type="file"
                         ref={fileInputRef}
@@ -289,7 +296,7 @@ export function CompletarActaAlumnoForm({ practica: initialPractica }: Completar
                         onChange={handleFileChange}
                         disabled={isOverallDisabled}
                       />
-                      <div className="flex flex-col sm:flex-row gap-2">
+                      <div className="flex flex-col sm:flex-row gap-2 items-start sm:items-center">
                         <Button
                           type="button"
                           variant="outline"
@@ -298,7 +305,7 @@ export function CompletarActaAlumnoForm({ practica: initialPractica }: Completar
                           disabled={isOverallDisabled}
                         >
                           <UploadCloud className="mr-2 h-4 w-4" />
-                          {selectedFile ? "Cambiar Foto" : "Seleccionar Foto"}
+                          {selectedFile ? "Cambiar Selección" : "Seleccionar Foto"}
                         </Button>
                         {selectedFile && (
                           <Button
@@ -307,13 +314,26 @@ export function CompletarActaAlumnoForm({ practica: initialPractica }: Completar
                             size="sm"
                             onClick={handleRemoveSelectedFile}
                             disabled={isOverallDisabled}
-                            className="text-xs text-muted-foreground hover:text-destructive"
+                            className="text-xs text-muted-foreground hover:text-destructive px-2"
                           >
-                            <Trash2 className="mr-1 h-3 w-3" /> Quitar selección
+                             <Trash2 className="mr-1 h-3 w-3" /> Quitar
                           </Button>
                         )}
                       </div>
-                       <FormDescription className="text-xs">
+                      {/* --- BOTÓN PARA SUBIR LA FOTO SELECCIONADA --- */}
+                      {selectedFile && !fileError && (
+                        <Button 
+                          type="button"
+                          onClick={handlePhotoUpload}
+                          size="sm" 
+                          disabled={isUploadingPhoto || isOverallDisabled} 
+                          className="bg-teal-600 hover:bg-teal-700 text-white w-full sm:w-auto mt-2"
+                        >
+                          <UploadCloud className="mr-2 h-4 w-4" />
+                          {isUploadingPhoto ? "Subiendo foto..." : "Confirmar y Subir Foto"}
+                        </Button>
+                      )}
+                       <FormDescription className="text-xs pt-1">
                         {ALLOWED_IMAGE_EXTENSIONS_STRING}. Máx {MAX_FILE_SIZE_KB_FOTO_PERFIL}KB.
                       </FormDescription>
                       {fileError && <p className="text-xs text-destructive mt-1">{fileError}</p>}

--- a/src/app/(main)/alumno/mis-practicas/[practicaId]/completar-acta/completar-acta-alumno-form.tsx
+++ b/src/app/(main)/alumno/mis-practicas/[practicaId]/completar-acta/completar-acta-alumno-form.tsx
@@ -34,7 +34,6 @@ import {
     UserCircle2, 
     UploadCloud, 
     Trash2, 
-    User
 } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
@@ -89,7 +88,7 @@ export function CompletarActaAlumnoForm({ practica: initialPractica }: Completar
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const [isUploadingPhoto, setIsUploadingPhoto] = React.useState(false); // Estado para subida de foto
 
-  const form = useForm<FormInputValues, any, CompletarActaAlumnoData>({
+  const form = useForm<FormInputValues, unknown, CompletarActaAlumnoData>({
     resolver: zodResolver(completarActaAlumnoSchema),
     defaultValues: {
       direccionCentro: practica.direccionCentro || "",

--- a/src/app/(main)/alumno/practicas/actions.ts
+++ b/src/app/(main)/alumno/practicas/actions.ts
@@ -12,6 +12,7 @@ import {
     type CompletarActaAlumnoData,
     type PracticaConDetalles 
 } from '@/lib/validators/practica'; 
+import { AlumnoService } from '@/lib/services/alumnoService';
 
 export type ActionResponse<TData = null> = {
   success: boolean;
@@ -117,5 +118,49 @@ export async function submitActaAlumnoAction(
       return { success: false, error: error.message };
     }
     return { success: false, error: 'Ocurrió un error muy inesperado al guardar el acta.' };
+  }
+}
+
+/**
+ * Actualiza la URL de la foto de perfil del Alumno logueado.
+ * @param newFotoUrl La URL de la imagen subida a Vercel Blob.
+ */
+export async function updateAlumnoFotoUrlAction(newFotoUrl: string): Promise<ActionResponse<{ fotoUrl: string | null }>> {
+  try {
+    const userPayload = await authorizeAlumno(); // Verifica que es un alumno y obtiene sus datos
+
+    // Encuentra el registro Alumno correspondiente al Usuario logueado
+    const alumno = await prismaClient.alumno.findUnique({
+      where: { usuarioId: userPayload.userId },
+      select: { id: true },
+    });
+
+    if (!alumno) {
+      return { success: false, error: "Perfil de alumno no encontrado." };
+    }
+
+    // Validación simple de la URL
+    if (!newFotoUrl || typeof newFotoUrl !== 'string' || !newFotoUrl.startsWith('https://')) {
+        return { success: false, error: "La URL de la foto proporcionada no es válida." };
+    }
+
+    const result = await AlumnoService.updateFotoUrl(alumno.id, newFotoUrl);
+
+    if (result.success && result.data) {
+      // Revalida las rutas donde la foto del alumno podría mostrarse
+      revalidatePath('/(main)/alumno/perfil', 'layout'); // Si tienes una página de perfil
+      revalidatePath('/(main)/alumno/mis-practicas', 'page'); // Si la foto se muestra en esta lista
+      revalidatePath('/(main)/layout', 'layout'); // Para refrescar Navbar si muestra foto
+      
+      return { success: true, data: { fotoUrl: result.data.fotoUrl } };
+    }
+    return { success: false, error: result.error || "No se pudo actualizar la foto de perfil." };
+
+  } catch (error) {
+    console.error("Error en updateAlumnoFotoUrlAction:", error);
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: "Ocurrió un error inesperado al actualizar la foto de perfil." };
   }
 }

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
@@ -12,12 +12,13 @@ import { RevisarActaDocenteCliente } from './revisar-acta-docente-client';
 const REQUIRED_ROLE: RoleName = 'DOCENTE';
 
 interface PageProps {
-  params: {
-    practicaId: string; // El ID vendrá como string de la URL
-  };
+  params: Promise<{practicaId: string}>
 }
 
-export default async function RevisarActaPage({ params }: PageProps) {
+export default async function RevisarActaPage({ params: paramsPromise }: PageProps) {
+
+  const params = await paramsPromise;
+
   const userPayload = await getUserSession();
 
   if (!userPayload) {

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
@@ -1,0 +1,86 @@
+// src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
+import { redirect } from 'next/navigation';
+import { getUserSession } from '@/lib/auth';
+import type { RoleName } from '@/types/roles';
+// Asegúrate que la ruta a las actions del docente sea correcta
+import { getDetallesPracticaParaRevisionDocenteAction, type ActionResponse } from '../../../practicas/actions'; 
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Terminal } from "lucide-react";
+import { RevisarActaDocenteCliente } from './revisar-acta-docente-client';
+
+const REQUIRED_ROLE: RoleName = 'DOCENTE';
+
+interface PageProps {
+  params: {
+    practicaId: string; // El ID vendrá como string de la URL
+  };
+}
+
+export default async function RevisarActaPage({ params }: PageProps) {
+  const userPayload = await getUserSession();
+
+  if (!userPayload) {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const loginUrl = new URL('/login', baseUrl);
+    redirect(loginUrl.toString());
+  }
+
+  if (userPayload.rol !== REQUIRED_ROLE) {
+    console.warn(
+      `Acceso no autorizado a /docente/practicas-pendientes/.../revisar-acta. Usuario RUT: ${userPayload.rut}, Rol: ${userPayload.rol}.`
+    );
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const dashboardUrl = new URL('/dashboard', baseUrl);
+    redirect(dashboardUrl.toString());
+  }
+
+  const practicaId = parseInt(params.practicaId, 10);
+  if (isNaN(practicaId)) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Alert variant="destructive">
+          <Terminal className="h-4 w-4" />
+          <AlertTitle>Error de Navegación</AlertTitle>
+          <AlertDescription>El ID de la práctica proporcionado no es válido.</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const result: ActionResponse<PracticaConDetalles> = await getDetallesPracticaParaRevisionDocenteAction(practicaId);
+  
+  if (!result.success || !result.data) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <header className="mb-8">
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Revisión de Acta de Práctica
+          </h1>
+        </header>
+        <Alert variant="destructive">
+          <Terminal className="h-4 w-4" />
+          <AlertTitle>Error al Cargar Práctica</AlertTitle>
+          <AlertDescription>{result.error || "No se pudo cargar la información de la práctica para revisión."}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const practica = result.data;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Revisión Acta 1: Práctica de {practica.alumno?.usuario.nombre} {practica.alumno?.usuario.apellido}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          RUT Alumno: {practica.alumno?.usuario.rut} <br/>
+          Carrera: {practica.carrera?.nombre} (Sede: {practica.carrera?.sede?.nombre || 'N/A'})
+        </p>
+      </header>
+      <RevisarActaDocenteCliente practica={practica} />
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/rejection-reason-modal.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/rejection-reason-modal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React from "react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { XCircle, Send } from "lucide-react";
+
+// Schema para el formulario de motivo de rechazo
+const rejectionSchema = z.object({
+  motivoRechazo: z.string()
+    .min(10, { message: "El motivo de rechazo debe tener al menos 10 caracteres." })
+    .max(1000, { message: "El motivo no puede exceder los 1000 caracteres." }),
+});
+type RejectionFormData = z.infer<typeof rejectionSchema>;
+
+interface RejectionReasonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => Promise<void>; // Callback que manejará la llamada a la Server Action
+  isSubmittingReason: boolean; // Para deshabilitar botones mientras se procesa
+}
+
+export function RejectionReasonModal({ 
+  isOpen, 
+  onClose, 
+  onSubmit, 
+  isSubmittingReason 
+}: RejectionReasonModalProps) {
+  const form = useForm<RejectionFormData>({
+    resolver: zodResolver(rejectionSchema),
+    defaultValues: {
+      motivoRechazo: "",
+    },
+  });
+
+  React.useEffect(() => {
+    if (isOpen) {
+      form.reset({ motivoRechazo: "" }); // Limpia el formulario al abrir
+      form.clearErrors();
+    }
+  }, [isOpen, form]);
+
+  const handleFormSubmit: SubmitHandler<RejectionFormData> = async (data) => {
+    await onSubmit(data.motivoRechazo); // Llama a la función onSubmit pasada por el padre
+    // El padre (RevisarActaDocenteCliente) se encargará de cerrar el modal si el submit es exitoso
+  };
+
+  return (
+    <Dialog 
+        open={isOpen} 
+        onOpenChange={(openStatus) => {
+            if (isSubmittingReason && !openStatus) return; // Prevenir cierre mientras se procesa
+            if (!openStatus) onClose(); // Si se cierra de otra forma (ej. Esc), llama a onClose
+        }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Indicar Motivo del Rechazo</DialogTitle>
+          <DialogDescription>
+            Por favor, explique brevemente por qué está rechazando la supervisión de esta práctica.
+            Esta información será comunicada al Coordinador.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-4 pt-2">
+            <FormField
+              control={form.control}
+              name="motivoRechazo"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Motivo del Rechazo <span className="text-red-500">*</span></FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Ej: La descripción de tareas no se alinea con los objetivos de la carrera..."
+                      className="min-h-[120px]"
+                      {...field}
+                      disabled={isSubmittingReason}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmittingReason}>
+                <XCircle className="mr-2 h-4 w-4" />
+                Cancelar
+              </Button>
+              <Button type="submit" variant="destructive" disabled={isSubmittingReason}>
+                <Send className="mr-2 h-4 w-4" />
+                {isSubmittingReason ? "Enviando..." : "Enviar Rechazo"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
@@ -1,0 +1,158 @@
+// src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+"use client";
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardHeader, 
+    CardTitle 
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, CalendarDays, ClipboardList } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { TipoPractica as PrismaTipoPracticaEnum, EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
+import { toast } from 'sonner'; // Para los placeholders de los botones
+
+interface RevisarActaDocenteClienteProps {
+  practica: PracticaConDetalles; // PracticaConDetalles ya incluye fueraDePlazo como opcional
+}
+
+const InfoItem: React.FC<{ 
+    label: string; 
+    value?: string | number | boolean | null | Date; 
+    isDate?: boolean; 
+    isBoolean?: boolean;
+    isList?: boolean;
+}> = ({ label, value, isDate, isBoolean, isList }) => {
+  let displayValue: React.ReactNode;
+
+  if (value === null || value === undefined || (typeof value === 'string' && value.trim() === '')) {
+    displayValue = <span className="text-muted-foreground italic">No provisto</span>;
+  } else if (isDate && value instanceof Date) {
+    displayValue = format(new Date(value), "PPP", { locale: es });
+  } else if (isBoolean) {
+    displayValue = value ? 'Sí' : 'No';
+  } else if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+    displayValue = <a href={value} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">{value} <ExternalLink className="inline h-3 w-3 ml-1"/></a>;
+  } else if (isList && typeof value === 'string') {
+    displayValue = <div className="whitespace-pre-wrap">{value}</div>;
+  }
+  else {
+    displayValue = value.toString();
+  }
+
+  return (
+    <div className="py-2">
+      <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{label}</dt>
+      <dd className="mt-1 text-sm text-foreground">{displayValue}</dd>
+    </div>
+  );
+};
+
+
+export function RevisarActaDocenteCliente({ practica }: RevisarActaDocenteClienteProps) {
+  const [isProcessing, setIsProcessing] = React.useState(false);
+  // const [isRejectModalOpen, setIsRejectModalOpen] = React.useState(false); 
+
+  const handleAccept = async () => {
+    setIsProcessing(true);
+    toast.info("Funcionalidad 'Aceptar Supervisión' se conectará en el próximo commit.");
+    console.log("Acción: Aceptar Supervisión para práctica ID:", practica.id);
+
+    // TODO: Llamar a submitDecisionDocenteActaAction 
+
+    await new Promise(resolve => setTimeout(resolve, 1000)); 
+    setIsProcessing(false);
+  };
+
+  const handleReject = () => {
+    toast.info("Funcionalidad 'Rechazar Supervisión' se conectará en el próximo commit.");
+    console.log("Acción: Rechazar Supervisión para práctica ID:", practica.id);
+    // TODO: Abrir modal de motivo de rechazo
+
+    // setIsRejectModalOpen(true);
+  };
+
+  const canDecide = practica.estado === PrismaEstadoPracticaEnum.PENDIENTE_ACEPTACION_DOCENTE;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="text-xl">Detalles de la Práctica</CardTitle>
+            <CardDescription>Información registrada por el Coordinador y el Alumno.</CardDescription>
+          </div>
+          <Badge variant={practica.estado === 'PENDIENTE_ACEPTACION_DOCENTE' ? 'destructive' : 'outline'} className="text-sm">
+            {practica.estado.replace(/_/g, ' ').toLowerCase()}
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          {/* Sección Coordinador */}
+          <div className="mb-6 pb-4 border-b">
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><Settings className="mr-2 h-5 w-5"/>Datos Registrados por Coordinación</h3>
+            <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+              <InfoItem label="Tipo de Práctica" value={practica.tipo === PrismaTipoPracticaEnum.LABORAL ? "Laboral" : "Profesional"} />
+              <InfoItem label="Fecha de Inicio" value={practica.fechaInicio} isDate />
+              <InfoItem label="Fecha de Término" value={practica.fechaTermino} isDate />
+            </dl>
+          </div>
+
+          {/* Sección Alumno */}
+          <div className="mb-6 pb-4 border-b">
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><User className="mr-2 h-5 w-5"/>Datos del Alumno</h3>
+             <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+              <InfoItem label="Nombre Completo" value={`${practica.alumno?.usuario.nombre} ${practica.alumno?.usuario.apellido}`} />
+              <InfoItem label="RUT" value={practica.alumno?.usuario.rut} />
+              <InfoItem label="Carrera" value={practica.carrera?.nombre} />
+              <InfoItem label="Sede de Carrera" value={practica.carrera?.sede?.nombre} />
+            </dl>
+          </div>
+          
+          {/* Sección Centro de Práctica (Alumno) */}
+          <div className="mb-6 pb-4 border-b">
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><Building className="mr-2 h-5 w-5"/>Información del Centro de Práctica</h3>
+             <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+              <InfoItem label="Dirección Centro" value={practica.direccionCentro} />
+              <InfoItem label="Departamento" value={practica.departamento} />
+              <InfoItem label="Nombre Jefe Directo" value={practica.nombreJefeDirecto} />
+              <InfoItem label="Cargo Jefe Directo" value={practica.cargoJefeDirecto} />
+              <InfoItem label="Email Jefe Directo" value={practica.contactoCorreoJefe} />
+              <InfoItem label="Teléfono Jefe Directo" value={practica.contactoTelefonoJefe} />
+              <InfoItem label="Práctica a Distancia" value={practica.practicaDistancia} isBoolean />
+            </dl>
+          </div>
+
+          {/* Sección Tareas (Alumno) */}
+           <div>
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><ClipboardList className="mr-2 h-5 w-5"/>Tareas Principales a Desempeñar</h3>
+            <div className="p-3 border rounded-md bg-slate-50 dark:bg-slate-800/50 text-sm">
+                <InfoItem label="" value={practica.tareasPrincipales} isList />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Botones de Acción */}
+      {canDecide && (
+        <div className="mt-8 flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-3">
+          <Button variant="destructive" onClick={handleReject} disabled={isProcessing} className="w-full sm:w-auto">
+            <XCircle className="mr-2 h-4 w-4" />
+            Rechazar Supervisión
+          </Button>
+          <Button variant="default" onClick={handleAccept} disabled={isProcessing} className="w-full sm:w-auto bg-green-600 hover:bg-green-700">
+            <CheckCircle className="mr-2 h-4 w-4" />
+            {isProcessing ? "Procesando..." : "Aceptar Supervisión"}
+          </Button>
+        </div>
+      )}
+
+      {/* Modal para motivo de rechazo se añadirá aquí */}
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
@@ -12,7 +12,7 @@ import {
     CardTitle 
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, CalendarDays, ClipboardList } from 'lucide-react';
+import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, ClipboardList } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import type { PracticaConDetalles, DecisionDocenteActaData } from '@/lib/validators/practica';

--- a/src/app/(main)/docente/practicas-pendientes/page.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/page.tsx
@@ -1,0 +1,45 @@
+// src/app/(main)/docente/practicas-pendientes/page.tsx
+import { redirect } from 'next/navigation';
+import { getUserSession } from '@/lib/auth';
+import type { RoleName } from '@/types/roles';
+// Asegúrate que la ruta a las actions del docente sea correcta
+import { getMisPracticasPendientesAceptacionAction, type ActionResponse } from '../practicas/actions'; 
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { PracticasPendientesDocenteCliente } from './practicas-pendientes-docente-client';
+
+const REQUIRED_ROLE: RoleName = 'DOCENTE';
+
+export default async function PracticasPendientesDocentePage() {
+  const userPayload = await getUserSession();
+
+  if (!userPayload) {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const loginUrl = new URL('/login', baseUrl);
+    redirect(loginUrl.toString());
+  }
+
+  if (userPayload.rol !== REQUIRED_ROLE) {
+    console.warn(
+      `Acceso no autorizado a /docente/practicas-pendientes. Usuario RUT: ${userPayload.rut}, Rol: ${userPayload.rol}. Rol requerido: ${REQUIRED_ROLE}`
+    );
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const dashboardUrl = new URL('/dashboard', baseUrl);
+    redirect(dashboardUrl.toString());
+  }
+
+  const result: ActionResponse<PracticaConDetalles[]> = await getMisPracticasPendientesAceptacionAction();
+  
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Prácticas Pendientes de Aceptación
+        </h1>
+        <p className="mt-2 text-lg text-gray-600 dark:text-gray-400">
+          A continuación, se listan las Actas 1 de los alumnos que le han sido asignados y requieren su revisión y aceptación.
+        </p>
+      </header>
+      <PracticasPendientesDocenteCliente initialActionResponse={result} />
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
@@ -12,7 +12,7 @@ import {
     CardTitle 
 } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { FileSpreadsheet, Terminal, Info, UserCheck } from 'lucide-react';
+import { Terminal, Info, UserCheck } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 
@@ -24,8 +24,8 @@ interface PracticasPendientesDocenteClienteProps {
 }
 
 export function PracticasPendientesDocenteCliente({ initialActionResponse }: PracticasPendientesDocenteClienteProps) {
-  const [practicas, setPracticas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
-  const [error, setError] = React.useState<string | null>(initialActionResponse.error || null);
+  const [practicas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
+  const [error] = React.useState<string | null>(initialActionResponse.error || null);
 
   if (error) {
     return (

--- a/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardFooter, 
+    CardHeader, 
+    CardTitle 
+} from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { FileSpreadsheet, Terminal, Info, UserCheck } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import type { ActionResponse } from '../practicas/actions';
+
+interface PracticasPendientesDocenteClienteProps {
+  initialActionResponse: ActionResponse<PracticaConDetalles[]>;
+}
+
+export function PracticasPendientesDocenteCliente({ initialActionResponse }: PracticasPendientesDocenteClienteProps) {
+  const [practicas, setPracticas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
+  const [error, setError] = React.useState<string | null>(initialActionResponse.error || null);
+
+  if (error) {
+    return (
+      <Alert variant="destructive" className="max-w-2xl mx-auto">
+        <Terminal className="h-4 w-4" />
+        <AlertTitle>Error al Cargar Prácticas</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (practicas.length === 0) {
+    return (
+      <div className="text-center py-10 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+        <Info className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+        <h3 className="mt-2 text-lg font-medium text-gray-900 dark:text-white">No tiene prácticas pendientes de aceptación</h3>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Cuando un alumno complete su Acta 1 y usted sea el tutor asignado, la práctica aparecerá aquí para su revisión.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {practicas.map((practica) => (
+        <Card key={practica.id} className="flex flex-col shadow-sm hover:shadow-lg transition-shadow">
+          <CardHeader>
+            <CardTitle className="text-lg">
+              {practica.alumno?.usuario.nombre} {practica.alumno?.usuario.apellido}
+            </CardTitle>
+            <CardDescription>
+              RUT: {practica.alumno?.usuario.rut} <br/>
+              Carrera: {practica.carrera?.nombre || 'N/A'} (Sede: {practica.carrera?.sede?.nombre || 'N/A'})
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm space-y-1 flex-grow">
+            <p><strong>Tipo:</strong> {practica.tipo === 'LABORAL' ? 'Laboral' : 'Profesional'}</p>
+            <p><strong>Inicio:</strong> {format(new Date(practica.fechaInicio), "P", { locale: es })}</p>
+            <p><strong>Término (Est.):</strong> {format(new Date(practica.fechaTermino), "P", { locale: es })}</p>
+            {practica.fechaCompletadoAlumno && (
+                <p className="text-xs text-muted-foreground pt-1">Acta completada por alumno: {format(new Date(practica.fechaCompletadoAlumno), "Pp", { locale: es })}</p>
+             )}
+          </CardContent>
+          <CardFooter className="border-t mt-auto">
+            <Button asChild size="sm" className="w-full mt-4">
+              <Link href={`/docente/practicas-pendientes/${practica.id}/revisar-acta`}>
+                <UserCheck className="mr-2 h-4 w-4" />
+                Revisar y Decidir Acta 1
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas/actions.ts
+++ b/src/app/(main)/docente/practicas/actions.ts
@@ -1,0 +1,134 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { ZodError } from 'zod';
+import { Prisma, EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
+
+import { authorizeDocente } from '@/lib/auth/checkRole'; 
+import { PracticaService } from '@/lib/services/practicaService';
+import prismaClient from '@/lib/prisma';
+import { 
+    decisionDocenteActaSchema,
+    type DecisionDocenteActaData,
+    type PracticaConDetalles
+} from '@/lib/validators/practica'; 
+
+// Definición de ActionResponse
+export type ActionResponse<TData = null> = {
+  success: boolean;
+  data?: TData;
+  error?: string;
+  errors?: { field: string | number | (string | number)[]; message: string }[];
+  message?: string;
+};
+
+/**
+ * Obtiene las prácticas asignadas al docente logueado que están pendientes de su aceptación/rechazo.
+ * Estado esperado: PENDIENTE_ACEPTACION_DOCENTE
+ */
+export async function getMisPracticasPendientesAceptacionAction(): Promise<ActionResponse<PracticaConDetalles[]>> {
+  try {
+    const userPayload = await authorizeDocente();
+
+    const docente = await prismaClient.docente.findUnique({
+        where: { usuarioId: userPayload.userId },
+        select: { id: true }
+    });
+
+    if (!docente) {
+        return { success: false, error: "Perfil de docente no encontrado para este usuario." };
+    }
+
+    const practicas = await prismaClient.practica.findMany({
+        where: {
+            docenteId: docente.id,
+            estado: PrismaEstadoPracticaEnum.PENDIENTE_ACEPTACION_DOCENTE,
+        },
+        include: { // Incluimos datos para mostrar en la lista
+            alumno: { include: { usuario: { select: { nombre: true, apellido: true, rut: true }} } },
+            carrera: { select: { nombre: true, sede: {select: {nombre:true}} } },
+        },
+        orderBy: { fechaInicio: 'asc' }
+    });
+    
+    return { success: true, data: practicas as unknown as PracticaConDetalles[] };
+
+  } catch (error) {
+    if (error instanceof Error) return { success: false, error: error.message };
+    return { success: false, error: 'Error inesperado obteniendo sus prácticas pendientes de aceptación.' };
+  }
+}
+
+/**
+ * Obtiene los detalles completos de una práctica para que el Docente la revise.
+ * Asegura que la práctica esté asignada al docente logueado y en el estado correcto.
+ */
+export async function getDetallesPracticaParaRevisionDocenteAction(practicaId: number): Promise<ActionResponse<PracticaConDetalles>> {
+  try {
+    const userPayload = await authorizeDocente(); 
+    const result = await PracticaService.getPracticaParaRevisionDocente(practicaId, userPayload.userId);
+
+    if (result.success && result.data) {
+      return { success: true, data: result.data as unknown as PracticaConDetalles };
+    }
+    return { success: false, error: result.error };
+  } catch (error) {
+    if (error instanceof Error) return { success: false, error: error.message };
+    return { success: false, error: 'Error inesperado obteniendo los detalles de la práctica.' };
+  }
+}
+
+/**
+ * Permite al Docente enviar su decisión (Aceptar/Rechazar) sobre el Acta 1.
+ */
+export async function submitDecisionDocenteActaAction(
+  practicaId: number, 
+  decisionData: DecisionDocenteActaData 
+): Promise<ActionResponse<PracticaConDetalles>> {
+  try {
+    const userPayload = await authorizeDocente();
+    
+    const validationResult = decisionDocenteActaSchema.safeParse(decisionData);
+    if (!validationResult.success) {
+      return {
+        success: false,
+        error: 'Datos de decisión inválidos.',
+        errors: validationResult.error.errors.map((e) => ({ field: e.path, message: e.message })),
+      };
+    }
+    
+    const result = await PracticaService.procesarDecisionDocenteActa(
+      practicaId, 
+      userPayload.userId, 
+      validationResult.data // Pasa los datos validados
+    );
+
+    if (result.success && result.data) {
+      revalidatePath(`/docente/alumnos-asignados`); // Para la lista
+      revalidatePath(`/docente/alumnos-asignados/${practicaId}/revisar-acta`); 
+      
+      // TODO: Notificación al Coordinador y Alumno
+
+      return { 
+         success: true, 
+         data: result.data as unknown as PracticaConDetalles, 
+         message: decisionData.decision === 'ACEPTADA' 
+             ? "Supervisión de práctica aceptada correctamente." 
+             : "Práctica rechazada. Se ha notificado al coordinador." // Mensaje genérico
+      };
+    }
+    return { success: false, error: result.error || 'Error desconocido al procesar la decisión.' };
+  } catch (error) {
+    if (error instanceof ZodError) { // Por si acaso, aunque ya se valida arriba
+        return {
+          success: false,
+          error: 'Error de validación.',
+          errors: error.errors.map((e) => ({ field: e.path, message: e.message })),
+        };
+    }
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: 'Ocurrió un error muy inesperado al procesar la decisión.' };
+  }
+}

--- a/src/app/(main)/docente/practicas/actions.ts
+++ b/src/app/(main)/docente/practicas/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { ZodError } from 'zod';
-import { Prisma, EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
+import { EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
 
 import { authorizeDocente } from '@/lib/auth/checkRole'; 
 import { PracticaService } from '@/lib/services/practicaService';

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,73 @@
 import { NextResponse } from 'next/server';
+import { put, del } from '@vercel/blob';
+import { nanoid } from 'nanoid';
 
-export async function GET() {
-  // Placeholder response
-  return NextResponse.json({ message: 'Hello from API' });
+// Constantes para validación de la foto de perfil del alumno
+const MAX_FILE_SIZE_KB_FOTO_PERFIL = 256; // 256 KB
+const MAX_FILE_SIZE_BYTES_FOTO_PERFIL = MAX_FILE_SIZE_KB_FOTO_PERFIL * 1024;
+const ALLOWED_CONTENT_TYPES_FOTO_PERFIL = ['image/jpeg', 'image/png', 'image/gif'];
+const UPLOAD_SUBFOLDER_FOTO_PERFIL = 'fotos-perfil-alumnos';
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No se recibió ningún archivo.' }, { status: 400 });
+    }
+
+    // Validar tipo de contenido
+    if (!ALLOWED_CONTENT_TYPES_FOTO_PERFIL.includes(file.type)) {
+      return NextResponse.json(
+        { error: `Tipo de archivo no permitido. Permitidos: JPG, PNG, GIF. Recibido: ${file.type}` },
+        { status: 400 }
+      );
+    }
+
+    // Validar tamaño del archivo
+    if (file.size > MAX_FILE_SIZE_BYTES_FOTO_PERFIL) {
+      return NextResponse.json(
+        { error: `El archivo excede el tamaño máximo de ${MAX_FILE_SIZE_KB_FOTO_PERFIL} KB.` },
+        { status: 400 }
+      );
+    }
+
+    // Generar un nombre de archivo único para evitar colisiones y añadir la extensión original
+    const fileExtension = file.name.split('.').pop()?.toLowerCase() || 'unknown';
+    const uniqueFilename = `${UPLOAD_SUBFOLDER_FOTO_PERFIL}/${nanoid()}.${fileExtension}`;
+
+    const blob = await put(uniqueFilename, file, {
+      access: 'public',
+      contentType: file.type, 
+    });
+
+    // Devolver la URL pública del blob
+    return NextResponse.json({ success: true, url: blob.url }, { status: 200 });
+
+  } catch (error) {
+    console.error('Error al subir el archivo:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Error desconocido.';
+    return NextResponse.json(
+        { error: `Error interno del servidor al subir el archivo: ${errorMessage}` }, 
+        { status: 500 }
+    );
+  }
+}
+
+// Manejo de eliminación de archivos subidos
+export async function DELETE(request: Request): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url);
+    const urlToDelete = searchParams.get('url');
+    if (!urlToDelete) {
+      return NextResponse.json({ error: 'URL del blob no proporcionada.' }, { status: 400 });
+    }
+    await del(urlToDelete);
+    return NextResponse.json({ success: true, message: 'Archivo eliminado.' });
+
+  } catch (error) {
+    console.error('Error al eliminar el archivo:', error);
+    return NextResponse.json({ error: 'Error interno al eliminar el archivo.' }, { status: 500 });
+  }
 }

--- a/src/lib/auth/checkRole.ts
+++ b/src/lib/auth/checkRole.ts
@@ -52,3 +52,10 @@ export async function authorizeCoordinador(): Promise<UserJwtPayload> {
 export async function authorizeAlumno(): Promise<UserJwtPayload> {
   return authorize('ALUMNO' as RoleName);
 }
+
+/**
+ * Helper específico para autorizar al Docente.
+ */
+export async function authorizeDocente(): Promise<UserJwtPayload> {
+  return authorize('DOCENTE' as RoleName);
+}

--- a/src/lib/services/alumnoService.ts
+++ b/src/lib/services/alumnoService.ts
@@ -2,6 +2,7 @@ import prisma from '@/lib/prisma';
 import { CreateAlumnoFormData } from '@/lib/validators';
 import { hashPassword } from '@/lib/auth';
 import { generateSecurePassword } from '@/lib/utils';
+import { Prisma } from '@prisma/client';
 
 export interface CreateAlumnoResponse {
   success: boolean;
@@ -174,6 +175,28 @@ export class AlumnoService {
     } catch (error) {
       console.error('Error al obtener alumnos para selección:', error);
       return { success: false, error: 'No se pudieron obtener los alumnos.' };
+    }
+  }
+
+  /**
+   * Actualiza la URL de la foto de perfil para un Alumno específico.
+   * @param alumnoId El ID del registro Alumno.
+   * @param fotoUrl La nueva URL de la foto.
+   */
+  static async updateFotoUrl(alumnoId: number, fotoUrl: string) {
+    try {
+      const updatedAlumno = await prisma.alumno.update({
+        where: { id: alumnoId },
+        data: { fotoUrl: fotoUrl },
+      });
+      return { success: true, data: updatedAlumno };
+    } catch (error) {
+      console.error(`Error al actualizar foto de perfil para el alumno ID ${alumnoId}:`, error);
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        // Error de registro no encontrado
+        return { success: false, error: 'Alumno no encontrado para actualizar la foto.' };
+      }
+      return { success: false, error: 'Error al guardar la URL de la foto en la base de datos.' };
     }
   }
 }

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -103,7 +103,7 @@ export interface PracticaConDetalles {
   practicaDistancia?: boolean | null;
   tareasPrincipales?: string | null;
   fechaCompletadoAlumno?: Date | null;
-  motivoRechazoDocente?: String | null;
+  motivoRechazoDocente?: string | null;
 
 
   // DATOS RELACIONALES 

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -103,6 +103,8 @@ export interface PracticaConDetalles {
   practicaDistancia?: boolean | null;
   tareasPrincipales?: string | null;
   fechaCompletadoAlumno?: Date | null;
+  motivoRechazoDocente?: String | null;
+
 
   // DATOS RELACIONALES 
   alumno?: { // Datos del alumno asociado

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -64,6 +64,23 @@ export const completarActaAlumnoSchema = z.object({
 
 export type CompletarActaAlumnoData = z.infer<typeof completarActaAlumnoSchema>;
 
+export const decisionDocenteActaSchema = z.object({
+  decision: z.enum(['ACEPTADA', 'RECHAZADA'], {
+    required_error: "La decisión (aceptar/rechazar) es requerida.",
+  }),
+  motivoRechazo: z.string().max(1000, "El motivo de rechazo no puede exceder los 1000 caracteres.").optional(),
+}).refine(data => {
+  // Si la decisión es RECHAZADA, el motivoRechazo se vuelve obligatorio y no puede estar vacío.
+  if (data.decision === 'RECHAZADA') {
+    return data.motivoRechazo && data.motivoRechazo.trim().length > 0;
+  }
+  return true; // Si es ACEPTADA, motivoRechazo no se envia)
+}, {
+  message: "El motivo de rechazo es requerido si se rechaza la supervisión.",
+  path: ['motivoRechazo'], // Asocia este error al campo motivoRechazo
+});
+
+export type DecisionDocenteActaData = z.infer<typeof decisionDocenteActaSchema>;
 
 // Interface general para Práctica con detalles
 export interface PracticaConDetalles {


### PR DESCRIPTION
Este Pull Request habilita la funcionalidad para que los Docentes Tutores revisen las Actas 1 de las prácticas que les han sido asignadas. Una vez que un alumno ha completado su sección del Acta 1, la práctica transita al estado `PENDIENTE_ACEPTACION_DOCENTE`. El docente asignado puede entonces acceder a una vista detallada del acta (con la información ingresada por el Coordinador y el Alumno, en modo solo lectura) y tomar una decisión: "Aceptar Supervisión" o "Rechazar Supervisión". Si se rechaza, el docente debe proporcionar un motivo. La aceptación cambia el estado de la práctica a `EN_CURSO`, permitiendo que el proceso continúe. El rechazo cambia el estado a `RECHAZADA_DOCENTE`.

**Cambios Implementados:**

**Backend:**
* **Modelo de Datos (`schema.prisma`):**
    * Se añadió el campo `motivoRechazoDocente: String? @db.Text` al modelo `Practica` para almacenar la justificación del docente en caso de rechazo.
    * Se verificó que el enum `EstadoPractica` contenga los estados requeridos: `PENDIENTE_ACEPTACION_DOCENTE`, `EN_CURSO`, y `RECHAZADA_DOCENTE`.
* **Validación (`src/lib/validators/practica.ts`):**
    * Se creó el schema Zod `decisionDocenteActaSchema` para validar la entrada del docente, que incluye la decisión (`ACEPTADA` o `RECHAZADA`) y un `motivoRechazo` opcional (pero requerido si la decisión es `RECHAZADA`).
* **Servicios (`PracticaService.ts`):**
    * `getPracticaParaRevisionDocente(practicaId, docenteUsuarioId)`: Nuevo método para obtener los detalles completos de una práctica específica, verificando que esté asignada al docente correcto y en estado `PENDIENTE_ACEPTACION_DOCENTE`.
    * `procesarDecisionDocenteActa(practicaId, docenteUsuarioId, decisionData)`: Nuevo método que actualiza el estado de la práctica a `EN_CURSO` si es aceptada, o a `RECHAZADA_DOCENTE` (guardando el `motivoRechazoDocente`) si es rechazada.
* **Autorización (`src/lib/auth/checkRole.ts`):**
    * Se implementó (o verificó) el helper `authorizeDocente()` para proteger las Server Actions específicas de este rol.
* **Server Actions (`src/app/(main)/docente/practicas/actions.ts`):**
    * `getMisPracticasPendientesAceptacionAction()`: Nueva action para que el docente autenticado liste las prácticas que requieren su decisión (estado `PENDIENTE_ACEPTACION_DOCENTE`).
    * `getDetallesPracticaParaRevisionDocenteAction(practicaId)`: Obtiene los datos de una práctica específica para la vista de revisión del docente.
    * `submitDecisionDocenteActaAction(practicaId, decisionData)`: Protegida por `authorizeDocente`, valida la entrada con `decisionDocenteActaSchema` y llama al servicio `PracticaService.procesarDecisionDocenteActa`. Incluye `revalidatePath` para actualizar las vistas relevantes.

**Frontend:**
* **Navegación:**
    * (Se asume la existencia de un enlace/botón, por ejemplo en `Navbar.tsx` o un dashboard del docente, que dirija a `/docente/practicas-pendientes`, visible solo para el rol 'DOCENTE', para cumplir CA1).
* **Página "Prácticas Pendientes de Aceptación" (`/docente/practicas-pendientes/page.tsx`):**
    * Nueva página protegida para el rol 'DOCENTE'.
    * Utiliza el componente cliente `PracticasPendientesDocenteCliente.tsx` para mostrar una lista (en formato de tarjetas) de las prácticas obtenidas con `getMisPracticasPendientesAceptacionAction`.
    * Cada práctica listada incluye información clave del alumno, carrera, sede y fechas, y un botón "Revisar y Decidir Acta 1".
* **Página "Revisar Acta 1" (`/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx`):**
    * Página dinámica protegida que carga y muestra los detalles completos de una práctica específica.
    * Renderiza `RevisarActaDocenteCliente.tsx`.
* **Vista de Revisión y Decisión (`RevisarActaDocenteCliente.tsx`):**
    * Muestra toda la información del Acta 1 (partes del Coordinador y del Alumno) en formato de solo lectura, organizada en secciones claras.
    * Presenta los botones "Aceptar Supervisión" y "Rechazar Supervisión" si la práctica está en el estado `PENDIENTE_ACEPTACION_DOCENTE`.
    * Al hacer clic en "Aceptar Supervisión", se llama a `submitDecisionDocenteActaAction` con la decisión "ACEPTADA".
    * Al hacer clic en "Rechazar Supervisión", se abre el modal `RejectionReasonModal.tsx`.
* **Modal de Motivo de Rechazo (`RejectionReasonModal.tsx`):**
    * Nuevo componente de diálogo que permite al docente ingresar un motivo (texto) para el rechazo.
    * Utiliza React Hook Form y Zod (`rejectionSchema`) para la validación del motivo.
    * Al enviar el motivo, se llama a `submitDecisionDocenteActaAction` con la decisión "RECHAZADA" y el motivo proporcionado.
* **Experiencia de Usuario:**
    * Gestión de estados de carga (`isProcessing`) en los botones de decisión y en el modal de rechazo.
    * Feedback al usuario mediante notificaciones toast (Sonner) para confirmar la acción o reportar errores.
    * Actualización del estado de la práctica en la UI de la página de revisión y deshabilitación de los botones de acción después de una decisión.