### PR TITLE
HU-23 - Docente Revisa y Decide Supervisión de Práctica (Acta 1)

### DIFF
--- a/prisma/migrations/20250528011648_add_motivo_rechazo_docente_practica/migration.sql
+++ b/prisma/migrations/20250528011648_add_motivo_rechazo_docente_practica/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Practica" ADD COLUMN     "motivoRechazoDocente" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model Practica {
   tareasPrincipales    String?        @db.Text
   
   fechaCompletadoAlumno DateTime?     
+  motivoRechazoDocente String? 
   
   // Otros campos
   informeUrl           String?        
@@ -227,14 +228,14 @@ enum TipoPractica {
 }
 
 enum EstadoPractica {
-  PENDIENTE                   // Iniciada por Coord, pendiente que Alumno complete
+  PENDIENTE                     // Iniciada por Coord, pendiente que Alumno complete
   PENDIENTE_ACEPTACION_DOCENTE  // Alumno completó, Docente Tutor debe revisar/aceptar
-  EN_CURSO                    // Docente aceptó/validó, práctica en desarrollo
-  FINALIZADA_PENDIENTE_EVAL   // Práctica terminada, informes/evaluaciones pendientes
-  EVALUACION_COMPLETA         // Todas las evaluaciones completadas
-  CERRADA                     // Proceso de práctica administrativamente cerrado (nota final asignada)
-  ANULADA                     // Práctica anulada
-  RECHAZADA_DOCENTE           // Acta 1 rechazada por el docente (requiere acción del coord/alumno)
+  RECHAZADA_DOCENTE             // Docente rechazó el Acta 1
+  EN_CURSO                      // Docente aceptó/validó, práctica en desarrollo
+  FINALIZADA_PENDIENTE_EVAL     // Práctica terminada, informes/evaluaciones pendientes
+  EVALUACION_COMPLETA           // Todas las evaluaciones completadas
+  CERRADA                       // Proceso de práctica administrativamente cerrado (nota final asignada)
+  ANULADA                       // Práctica anulada
 }
 
 enum EstadoActaFinal {

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
@@ -12,12 +12,13 @@ import { RevisarActaDocenteCliente } from './revisar-acta-docente-client';
 const REQUIRED_ROLE: RoleName = 'DOCENTE';
 
 interface PageProps {
-  params: {
-    practicaId: string; // El ID vendrá como string de la URL
-  };
+  params: Promise<{practicaId: string}>
 }
 
-export default async function RevisarActaPage({ params }: PageProps) {
+export default async function RevisarActaPage({ params: paramsPromise }: PageProps) {
+
+  const params = await paramsPromise;
+
   const userPayload = await getUserSession();
 
   if (!userPayload) {

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
@@ -1,0 +1,86 @@
+// src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx
+import { redirect } from 'next/navigation';
+import { getUserSession } from '@/lib/auth';
+import type { RoleName } from '@/types/roles';
+// Asegúrate que la ruta a las actions del docente sea correcta
+import { getDetallesPracticaParaRevisionDocenteAction, type ActionResponse } from '../../../practicas/actions'; 
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Terminal } from "lucide-react";
+import { RevisarActaDocenteCliente } from './revisar-acta-docente-client';
+
+const REQUIRED_ROLE: RoleName = 'DOCENTE';
+
+interface PageProps {
+  params: {
+    practicaId: string; // El ID vendrá como string de la URL
+  };
+}
+
+export default async function RevisarActaPage({ params }: PageProps) {
+  const userPayload = await getUserSession();
+
+  if (!userPayload) {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const loginUrl = new URL('/login', baseUrl);
+    redirect(loginUrl.toString());
+  }
+
+  if (userPayload.rol !== REQUIRED_ROLE) {
+    console.warn(
+      `Acceso no autorizado a /docente/practicas-pendientes/.../revisar-acta. Usuario RUT: ${userPayload.rut}, Rol: ${userPayload.rol}.`
+    );
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const dashboardUrl = new URL('/dashboard', baseUrl);
+    redirect(dashboardUrl.toString());
+  }
+
+  const practicaId = parseInt(params.practicaId, 10);
+  if (isNaN(practicaId)) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Alert variant="destructive">
+          <Terminal className="h-4 w-4" />
+          <AlertTitle>Error de Navegación</AlertTitle>
+          <AlertDescription>El ID de la práctica proporcionado no es válido.</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const result: ActionResponse<PracticaConDetalles> = await getDetallesPracticaParaRevisionDocenteAction(practicaId);
+  
+  if (!result.success || !result.data) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <header className="mb-8">
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Revisión de Acta de Práctica
+          </h1>
+        </header>
+        <Alert variant="destructive">
+          <Terminal className="h-4 w-4" />
+          <AlertTitle>Error al Cargar Práctica</AlertTitle>
+          <AlertDescription>{result.error || "No se pudo cargar la información de la práctica para revisión."}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const practica = result.data;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Revisión Acta 1: Práctica de {practica.alumno?.usuario.nombre} {practica.alumno?.usuario.apellido}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          RUT Alumno: {practica.alumno?.usuario.rut} <br/>
+          Carrera: {practica.carrera?.nombre} (Sede: {practica.carrera?.sede?.nombre || 'N/A'})
+        </p>
+      </header>
+      <RevisarActaDocenteCliente practica={practica} />
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/rejection-reason-modal.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/rejection-reason-modal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React from "react";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { XCircle, Send } from "lucide-react";
+
+// Schema para el formulario de motivo de rechazo
+const rejectionSchema = z.object({
+  motivoRechazo: z.string()
+    .min(10, { message: "El motivo de rechazo debe tener al menos 10 caracteres." })
+    .max(1000, { message: "El motivo no puede exceder los 1000 caracteres." }),
+});
+type RejectionFormData = z.infer<typeof rejectionSchema>;
+
+interface RejectionReasonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => Promise<void>; // Callback que manejará la llamada a la Server Action
+  isSubmittingReason: boolean; // Para deshabilitar botones mientras se procesa
+}
+
+export function RejectionReasonModal({ 
+  isOpen, 
+  onClose, 
+  onSubmit, 
+  isSubmittingReason 
+}: RejectionReasonModalProps) {
+  const form = useForm<RejectionFormData>({
+    resolver: zodResolver(rejectionSchema),
+    defaultValues: {
+      motivoRechazo: "",
+    },
+  });
+
+  React.useEffect(() => {
+    if (isOpen) {
+      form.reset({ motivoRechazo: "" }); // Limpia el formulario al abrir
+      form.clearErrors();
+    }
+  }, [isOpen, form]);
+
+  const handleFormSubmit: SubmitHandler<RejectionFormData> = async (data) => {
+    await onSubmit(data.motivoRechazo); // Llama a la función onSubmit pasada por el padre
+    // El padre (RevisarActaDocenteCliente) se encargará de cerrar el modal si el submit es exitoso
+  };
+
+  return (
+    <Dialog 
+        open={isOpen} 
+        onOpenChange={(openStatus) => {
+            if (isSubmittingReason && !openStatus) return; // Prevenir cierre mientras se procesa
+            if (!openStatus) onClose(); // Si se cierra de otra forma (ej. Esc), llama a onClose
+        }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Indicar Motivo del Rechazo</DialogTitle>
+          <DialogDescription>
+            Por favor, explique brevemente por qué está rechazando la supervisión de esta práctica.
+            Esta información será comunicada al Coordinador.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-4 pt-2">
+            <FormField
+              control={form.control}
+              name="motivoRechazo"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Motivo del Rechazo <span className="text-red-500">*</span></FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Ej: La descripción de tareas no se alinea con los objetivos de la carrera..."
+                      className="min-h-[120px]"
+                      {...field}
+                      disabled={isSubmittingReason}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter className="gap-2 sm:gap-0">
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmittingReason}>
+                <XCircle className="mr-2 h-4 w-4" />
+                Cancelar
+              </Button>
+              <Button type="submit" variant="destructive" disabled={isSubmittingReason}>
+                <Send className="mr-2 h-4 w-4" />
+                {isSubmittingReason ? "Enviando..." : "Enviar Rechazo"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
@@ -1,0 +1,158 @@
+// src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+"use client";
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardHeader, 
+    CardTitle 
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, CalendarDays, ClipboardList } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { TipoPractica as PrismaTipoPracticaEnum, EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
+import { toast } from 'sonner'; // Para los placeholders de los botones
+
+interface RevisarActaDocenteClienteProps {
+  practica: PracticaConDetalles; // PracticaConDetalles ya incluye fueraDePlazo como opcional
+}
+
+const InfoItem: React.FC<{ 
+    label: string; 
+    value?: string | number | boolean | null | Date; 
+    isDate?: boolean; 
+    isBoolean?: boolean;
+    isList?: boolean;
+}> = ({ label, value, isDate, isBoolean, isList }) => {
+  let displayValue: React.ReactNode;
+
+  if (value === null || value === undefined || (typeof value === 'string' && value.trim() === '')) {
+    displayValue = <span className="text-muted-foreground italic">No provisto</span>;
+  } else if (isDate && value instanceof Date) {
+    displayValue = format(new Date(value), "PPP", { locale: es });
+  } else if (isBoolean) {
+    displayValue = value ? 'Sí' : 'No';
+  } else if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+    displayValue = <a href={value} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">{value} <ExternalLink className="inline h-3 w-3 ml-1"/></a>;
+  } else if (isList && typeof value === 'string') {
+    displayValue = <div className="whitespace-pre-wrap">{value}</div>;
+  }
+  else {
+    displayValue = value.toString();
+  }
+
+  return (
+    <div className="py-2">
+      <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{label}</dt>
+      <dd className="mt-1 text-sm text-foreground">{displayValue}</dd>
+    </div>
+  );
+};
+
+
+export function RevisarActaDocenteCliente({ practica }: RevisarActaDocenteClienteProps) {
+  const [isProcessing, setIsProcessing] = React.useState(false);
+  // const [isRejectModalOpen, setIsRejectModalOpen] = React.useState(false); 
+
+  const handleAccept = async () => {
+    setIsProcessing(true);
+    toast.info("Funcionalidad 'Aceptar Supervisión' se conectará en el próximo commit.");
+    console.log("Acción: Aceptar Supervisión para práctica ID:", practica.id);
+
+    // TODO: Llamar a submitDecisionDocenteActaAction 
+
+    await new Promise(resolve => setTimeout(resolve, 1000)); 
+    setIsProcessing(false);
+  };
+
+  const handleReject = () => {
+    toast.info("Funcionalidad 'Rechazar Supervisión' se conectará en el próximo commit.");
+    console.log("Acción: Rechazar Supervisión para práctica ID:", practica.id);
+    // TODO: Abrir modal de motivo de rechazo
+
+    // setIsRejectModalOpen(true);
+  };
+
+  const canDecide = practica.estado === PrismaEstadoPracticaEnum.PENDIENTE_ACEPTACION_DOCENTE;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle className="text-xl">Detalles de la Práctica</CardTitle>
+            <CardDescription>Información registrada por el Coordinador y el Alumno.</CardDescription>
+          </div>
+          <Badge variant={practica.estado === 'PENDIENTE_ACEPTACION_DOCENTE' ? 'destructive' : 'outline'} className="text-sm">
+            {practica.estado.replace(/_/g, ' ').toLowerCase()}
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          {/* Sección Coordinador */}
+          <div className="mb-6 pb-4 border-b">
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><Settings className="mr-2 h-5 w-5"/>Datos Registrados por Coordinación</h3>
+            <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+              <InfoItem label="Tipo de Práctica" value={practica.tipo === PrismaTipoPracticaEnum.LABORAL ? "Laboral" : "Profesional"} />
+              <InfoItem label="Fecha de Inicio" value={practica.fechaInicio} isDate />
+              <InfoItem label="Fecha de Término" value={practica.fechaTermino} isDate />
+            </dl>
+          </div>
+
+          {/* Sección Alumno */}
+          <div className="mb-6 pb-4 border-b">
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><User className="mr-2 h-5 w-5"/>Datos del Alumno</h3>
+             <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+              <InfoItem label="Nombre Completo" value={`${practica.alumno?.usuario.nombre} ${practica.alumno?.usuario.apellido}`} />
+              <InfoItem label="RUT" value={practica.alumno?.usuario.rut} />
+              <InfoItem label="Carrera" value={practica.carrera?.nombre} />
+              <InfoItem label="Sede de Carrera" value={practica.carrera?.sede?.nombre} />
+            </dl>
+          </div>
+          
+          {/* Sección Centro de Práctica (Alumno) */}
+          <div className="mb-6 pb-4 border-b">
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><Building className="mr-2 h-5 w-5"/>Información del Centro de Práctica</h3>
+             <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+              <InfoItem label="Dirección Centro" value={practica.direccionCentro} />
+              <InfoItem label="Departamento" value={practica.departamento} />
+              <InfoItem label="Nombre Jefe Directo" value={practica.nombreJefeDirecto} />
+              <InfoItem label="Cargo Jefe Directo" value={practica.cargoJefeDirecto} />
+              <InfoItem label="Email Jefe Directo" value={practica.contactoCorreoJefe} />
+              <InfoItem label="Teléfono Jefe Directo" value={practica.contactoTelefonoJefe} />
+              <InfoItem label="Práctica a Distancia" value={practica.practicaDistancia} isBoolean />
+            </dl>
+          </div>
+
+          {/* Sección Tareas (Alumno) */}
+           <div>
+            <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center"><ClipboardList className="mr-2 h-5 w-5"/>Tareas Principales a Desempeñar</h3>
+            <div className="p-3 border rounded-md bg-slate-50 dark:bg-slate-800/50 text-sm">
+                <InfoItem label="" value={practica.tareasPrincipales} isList />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Botones de Acción */}
+      {canDecide && (
+        <div className="mt-8 flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-3">
+          <Button variant="destructive" onClick={handleReject} disabled={isProcessing} className="w-full sm:w-auto">
+            <XCircle className="mr-2 h-4 w-4" />
+            Rechazar Supervisión
+          </Button>
+          <Button variant="default" onClick={handleAccept} disabled={isProcessing} className="w-full sm:w-auto bg-green-600 hover:bg-green-700">
+            <CheckCircle className="mr-2 h-4 w-4" />
+            {isProcessing ? "Procesando..." : "Aceptar Supervisión"}
+          </Button>
+        </div>
+      )}
+
+      {/* Modal para motivo de rechazo se añadirá aquí */}
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
@@ -12,7 +12,7 @@ import {
     CardTitle 
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, CalendarDays, ClipboardList } from 'lucide-react';
+import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, ClipboardList } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import type { PracticaConDetalles, DecisionDocenteActaData } from '@/lib/validators/practica';

--- a/src/app/(main)/docente/practicas-pendientes/page.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/page.tsx
@@ -1,0 +1,45 @@
+// src/app/(main)/docente/practicas-pendientes/page.tsx
+import { redirect } from 'next/navigation';
+import { getUserSession } from '@/lib/auth';
+import type { RoleName } from '@/types/roles';
+// Asegúrate que la ruta a las actions del docente sea correcta
+import { getMisPracticasPendientesAceptacionAction, type ActionResponse } from '../practicas/actions'; 
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { PracticasPendientesDocenteCliente } from './practicas-pendientes-docente-client';
+
+const REQUIRED_ROLE: RoleName = 'DOCENTE';
+
+export default async function PracticasPendientesDocentePage() {
+  const userPayload = await getUserSession();
+
+  if (!userPayload) {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const loginUrl = new URL('/login', baseUrl);
+    redirect(loginUrl.toString());
+  }
+
+  if (userPayload.rol !== REQUIRED_ROLE) {
+    console.warn(
+      `Acceso no autorizado a /docente/practicas-pendientes. Usuario RUT: ${userPayload.rut}, Rol: ${userPayload.rol}. Rol requerido: ${REQUIRED_ROLE}`
+    );
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const dashboardUrl = new URL('/dashboard', baseUrl);
+    redirect(dashboardUrl.toString());
+  }
+
+  const result: ActionResponse<PracticaConDetalles[]> = await getMisPracticasPendientesAceptacionAction();
+  
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Prácticas Pendientes de Aceptación
+        </h1>
+        <p className="mt-2 text-lg text-gray-600 dark:text-gray-400">
+          A continuación, se listan las Actas 1 de los alumnos que le han sido asignados y requieren su revisión y aceptación.
+        </p>
+      </header>
+      <PracticasPendientesDocenteCliente initialActionResponse={result} />
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
@@ -12,7 +12,7 @@ import {
     CardTitle 
 } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { FileSpreadsheet, Terminal, Info, UserCheck } from 'lucide-react';
+import { Terminal, Info, UserCheck } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 
@@ -24,8 +24,8 @@ interface PracticasPendientesDocenteClienteProps {
 }
 
 export function PracticasPendientesDocenteCliente({ initialActionResponse }: PracticasPendientesDocenteClienteProps) {
-  const [practicas, setPracticas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
-  const [error, setError] = React.useState<string | null>(initialActionResponse.error || null);
+  const [practicas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
+  const [error] = React.useState<string | null>(initialActionResponse.error || null);
 
   if (error) {
     return (

--- a/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/practicas-pendientes-docente-client.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardFooter, 
+    CardHeader, 
+    CardTitle 
+} from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { FileSpreadsheet, Terminal, Info, UserCheck } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import type { ActionResponse } from '../practicas/actions';
+
+interface PracticasPendientesDocenteClienteProps {
+  initialActionResponse: ActionResponse<PracticaConDetalles[]>;
+}
+
+export function PracticasPendientesDocenteCliente({ initialActionResponse }: PracticasPendientesDocenteClienteProps) {
+  const [practicas, setPracticas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
+  const [error, setError] = React.useState<string | null>(initialActionResponse.error || null);
+
+  if (error) {
+    return (
+      <Alert variant="destructive" className="max-w-2xl mx-auto">
+        <Terminal className="h-4 w-4" />
+        <AlertTitle>Error al Cargar Prácticas</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (practicas.length === 0) {
+    return (
+      <div className="text-center py-10 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+        <Info className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+        <h3 className="mt-2 text-lg font-medium text-gray-900 dark:text-white">No tiene prácticas pendientes de aceptación</h3>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Cuando un alumno complete su Acta 1 y usted sea el tutor asignado, la práctica aparecerá aquí para su revisión.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {practicas.map((practica) => (
+        <Card key={practica.id} className="flex flex-col shadow-sm hover:shadow-lg transition-shadow">
+          <CardHeader>
+            <CardTitle className="text-lg">
+              {practica.alumno?.usuario.nombre} {practica.alumno?.usuario.apellido}
+            </CardTitle>
+            <CardDescription>
+              RUT: {practica.alumno?.usuario.rut} <br/>
+              Carrera: {practica.carrera?.nombre || 'N/A'} (Sede: {practica.carrera?.sede?.nombre || 'N/A'})
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm space-y-1 flex-grow">
+            <p><strong>Tipo:</strong> {practica.tipo === 'LABORAL' ? 'Laboral' : 'Profesional'}</p>
+            <p><strong>Inicio:</strong> {format(new Date(practica.fechaInicio), "P", { locale: es })}</p>
+            <p><strong>Término (Est.):</strong> {format(new Date(practica.fechaTermino), "P", { locale: es })}</p>
+            {practica.fechaCompletadoAlumno && (
+                <p className="text-xs text-muted-foreground pt-1">Acta completada por alumno: {format(new Date(practica.fechaCompletadoAlumno), "Pp", { locale: es })}</p>
+             )}
+          </CardContent>
+          <CardFooter className="border-t mt-auto">
+            <Button asChild size="sm" className="w-full mt-4">
+              <Link href={`/docente/practicas-pendientes/${practica.id}/revisar-acta`}>
+                <UserCheck className="mr-2 h-4 w-4" />
+                Revisar y Decidir Acta 1
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(main)/docente/practicas/actions.ts
+++ b/src/app/(main)/docente/practicas/actions.ts
@@ -1,0 +1,134 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { ZodError } from 'zod';
+import { Prisma, EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
+
+import { authorizeDocente } from '@/lib/auth/checkRole'; 
+import { PracticaService } from '@/lib/services/practicaService';
+import prismaClient from '@/lib/prisma';
+import { 
+    decisionDocenteActaSchema,
+    type DecisionDocenteActaData,
+    type PracticaConDetalles
+} from '@/lib/validators/practica'; 
+
+// Definición de ActionResponse
+export type ActionResponse<TData = null> = {
+  success: boolean;
+  data?: TData;
+  error?: string;
+  errors?: { field: string | number | (string | number)[]; message: string }[];
+  message?: string;
+};
+
+/**
+ * Obtiene las prácticas asignadas al docente logueado que están pendientes de su aceptación/rechazo.
+ * Estado esperado: PENDIENTE_ACEPTACION_DOCENTE
+ */
+export async function getMisPracticasPendientesAceptacionAction(): Promise<ActionResponse<PracticaConDetalles[]>> {
+  try {
+    const userPayload = await authorizeDocente();
+
+    const docente = await prismaClient.docente.findUnique({
+        where: { usuarioId: userPayload.userId },
+        select: { id: true }
+    });
+
+    if (!docente) {
+        return { success: false, error: "Perfil de docente no encontrado para este usuario." };
+    }
+
+    const practicas = await prismaClient.practica.findMany({
+        where: {
+            docenteId: docente.id,
+            estado: PrismaEstadoPracticaEnum.PENDIENTE_ACEPTACION_DOCENTE,
+        },
+        include: { // Incluimos datos para mostrar en la lista
+            alumno: { include: { usuario: { select: { nombre: true, apellido: true, rut: true }} } },
+            carrera: { select: { nombre: true, sede: {select: {nombre:true}} } },
+        },
+        orderBy: { fechaInicio: 'asc' }
+    });
+    
+    return { success: true, data: practicas as unknown as PracticaConDetalles[] };
+
+  } catch (error) {
+    if (error instanceof Error) return { success: false, error: error.message };
+    return { success: false, error: 'Error inesperado obteniendo sus prácticas pendientes de aceptación.' };
+  }
+}
+
+/**
+ * Obtiene los detalles completos de una práctica para que el Docente la revise.
+ * Asegura que la práctica esté asignada al docente logueado y en el estado correcto.
+ */
+export async function getDetallesPracticaParaRevisionDocenteAction(practicaId: number): Promise<ActionResponse<PracticaConDetalles>> {
+  try {
+    const userPayload = await authorizeDocente(); 
+    const result = await PracticaService.getPracticaParaRevisionDocente(practicaId, userPayload.userId);
+
+    if (result.success && result.data) {
+      return { success: true, data: result.data as unknown as PracticaConDetalles };
+    }
+    return { success: false, error: result.error };
+  } catch (error) {
+    if (error instanceof Error) return { success: false, error: error.message };
+    return { success: false, error: 'Error inesperado obteniendo los detalles de la práctica.' };
+  }
+}
+
+/**
+ * Permite al Docente enviar su decisión (Aceptar/Rechazar) sobre el Acta 1.
+ */
+export async function submitDecisionDocenteActaAction(
+  practicaId: number, 
+  decisionData: DecisionDocenteActaData 
+): Promise<ActionResponse<PracticaConDetalles>> {
+  try {
+    const userPayload = await authorizeDocente();
+    
+    const validationResult = decisionDocenteActaSchema.safeParse(decisionData);
+    if (!validationResult.success) {
+      return {
+        success: false,
+        error: 'Datos de decisión inválidos.',
+        errors: validationResult.error.errors.map((e) => ({ field: e.path, message: e.message })),
+      };
+    }
+    
+    const result = await PracticaService.procesarDecisionDocenteActa(
+      practicaId, 
+      userPayload.userId, 
+      validationResult.data // Pasa los datos validados
+    );
+
+    if (result.success && result.data) {
+      revalidatePath(`/docente/alumnos-asignados`); // Para la lista
+      revalidatePath(`/docente/alumnos-asignados/${practicaId}/revisar-acta`); 
+      
+      // TODO: Notificación al Coordinador y Alumno
+
+      return { 
+         success: true, 
+         data: result.data as unknown as PracticaConDetalles, 
+         message: decisionData.decision === 'ACEPTADA' 
+             ? "Supervisión de práctica aceptada correctamente." 
+             : "Práctica rechazada. Se ha notificado al coordinador." // Mensaje genérico
+      };
+    }
+    return { success: false, error: result.error || 'Error desconocido al procesar la decisión.' };
+  } catch (error) {
+    if (error instanceof ZodError) { // Por si acaso, aunque ya se valida arriba
+        return {
+          success: false,
+          error: 'Error de validación.',
+          errors: error.errors.map((e) => ({ field: e.path, message: e.message })),
+        };
+    }
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+    return { success: false, error: 'Ocurrió un error muy inesperado al procesar la decisión.' };
+  }
+}

--- a/src/app/(main)/docente/practicas/actions.ts
+++ b/src/app/(main)/docente/practicas/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { ZodError } from 'zod';
-import { Prisma, EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
+import { EstadoPractica as PrismaEstadoPracticaEnum } from '@prisma/client';
 
 import { authorizeDocente } from '@/lib/auth/checkRole'; 
 import { PracticaService } from '@/lib/services/practicaService';

--- a/src/lib/auth/checkRole.ts
+++ b/src/lib/auth/checkRole.ts
@@ -52,3 +52,10 @@ export async function authorizeCoordinador(): Promise<UserJwtPayload> {
 export async function authorizeAlumno(): Promise<UserJwtPayload> {
   return authorize('ALUMNO' as RoleName);
 }
+
+/**
+ * Helper específico para autorizar al Docente.
+ */
+export async function authorizeDocente(): Promise<UserJwtPayload> {
+  return authorize('DOCENTE' as RoleName);
+}

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -103,7 +103,7 @@ export interface PracticaConDetalles {
   practicaDistancia?: boolean | null;
   tareasPrincipales?: string | null;
   fechaCompletadoAlumno?: Date | null;
-  motivoRechazoDocente?: String | null;
+  motivoRechazoDocente?: string | null;
 
 
   // DATOS RELACIONALES 

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -103,6 +103,8 @@ export interface PracticaConDetalles {
   practicaDistancia?: boolean | null;
   tareasPrincipales?: string | null;
   fechaCompletadoAlumno?: Date | null;
+  motivoRechazoDocente?: String | null;
+
 
   // DATOS RELACIONALES 
   alumno?: { // Datos del alumno asociado

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -64,6 +64,23 @@ export const completarActaAlumnoSchema = z.object({
 
 export type CompletarActaAlumnoData = z.infer<typeof completarActaAlumnoSchema>;
 
+export const decisionDocenteActaSchema = z.object({
+  decision: z.enum(['ACEPTADA', 'RECHAZADA'], {
+    required_error: "La decisión (aceptar/rechazar) es requerida.",
+  }),
+  motivoRechazo: z.string().max(1000, "El motivo de rechazo no puede exceder los 1000 caracteres.").optional(),
+}).refine(data => {
+  // Si la decisión es RECHAZADA, el motivoRechazo se vuelve obligatorio y no puede estar vacío.
+  if (data.decision === 'RECHAZADA') {
+    return data.motivoRechazo && data.motivoRechazo.trim().length > 0;
+  }
+  return true; // Si es ACEPTADA, motivoRechazo no se envia)
+}, {
+  message: "El motivo de rechazo es requerido si se rechaza la supervisión.",
+  path: ['motivoRechazo'], // Asocia este error al campo motivoRechazo
+});
+
+export type DecisionDocenteActaData = z.infer<typeof decisionDocenteActaSchema>;
 
 // Interface general para Práctica con detalles
 export interface PracticaConDetalles {


### PR DESCRIPTION
Este Pull Request habilita la funcionalidad para que los Docentes Tutores revisen las Actas 1 de las prácticas que les han sido asignadas. Una vez que un alumno ha completado su sección del Acta 1, la práctica transita al estado `PENDIENTE_ACEPTACION_DOCENTE`. El docente asignado puede entonces acceder a una vista detallada del acta (con la información ingresada por el Coordinador y el Alumno, en modo solo lectura) y tomar una decisión: "Aceptar Supervisión" o "Rechazar Supervisión". Si se rechaza, el docente debe proporcionar un motivo. La aceptación cambia el estado de la práctica a `EN_CURSO`, permitiendo que el proceso continúe. El rechazo cambia el estado a `RECHAZADA_DOCENTE`.

**Cambios Implementados:**

**Backend:**
* **Modelo de Datos (`schema.prisma`):**
    * Se añadió el campo `motivoRechazoDocente: String? @db.Text` al modelo `Practica` para almacenar la justificación del docente en caso de rechazo.
    * Se verificó que el enum `EstadoPractica` contenga los estados requeridos: `PENDIENTE_ACEPTACION_DOCENTE`, `EN_CURSO`, y `RECHAZADA_DOCENTE`.
* **Validación (`src/lib/validators/practica.ts`):**
    * Se creó el schema Zod `decisionDocenteActaSchema` para validar la entrada del docente, que incluye la decisión (`ACEPTADA` o `RECHAZADA`) y un `motivoRechazo` opcional (pero requerido si la decisión es `RECHAZADA`).
* **Servicios (`PracticaService.ts`):**
    * `getPracticaParaRevisionDocente(practicaId, docenteUsuarioId)`: Nuevo método para obtener los detalles completos de una práctica específica, verificando que esté asignada al docente correcto y en estado `PENDIENTE_ACEPTACION_DOCENTE`.
    * `procesarDecisionDocenteActa(practicaId, docenteUsuarioId, decisionData)`: Nuevo método que actualiza el estado de la práctica a `EN_CURSO` si es aceptada, o a `RECHAZADA_DOCENTE` (guardando el `motivoRechazoDocente`) si es rechazada.
* **Autorización (`src/lib/auth/checkRole.ts`):**
    * Se implementó (o verificó) el helper `authorizeDocente()` para proteger las Server Actions específicas de este rol.
* **Server Actions (`src/app/(main)/docente/practicas/actions.ts`):**
    * `getMisPracticasPendientesAceptacionAction()`: Nueva action para que el docente autenticado liste las prácticas que requieren su decisión (estado `PENDIENTE_ACEPTACION_DOCENTE`).
    * `getDetallesPracticaParaRevisionDocenteAction(practicaId)`: Obtiene los datos de una práctica específica para la vista de revisión del docente.
    * `submitDecisionDocenteActaAction(practicaId, decisionData)`: Protegida por `authorizeDocente`, valida la entrada con `decisionDocenteActaSchema` y llama al servicio `PracticaService.procesarDecisionDocenteActa`. Incluye `revalidatePath` para actualizar las vistas relevantes.

**Frontend:**
* **Navegación:**
    * (Se asume la existencia de un enlace/botón, por ejemplo en `Navbar.tsx` o un dashboard del docente, que dirija a `/docente/practicas-pendientes`, visible solo para el rol 'DOCENTE', para cumplir CA1).
* **Página "Prácticas Pendientes de Aceptación" (`/docente/practicas-pendientes/page.tsx`):**
    * Nueva página protegida para el rol 'DOCENTE'.
    * Utiliza el componente cliente `PracticasPendientesDocenteCliente.tsx` para mostrar una lista (en formato de tarjetas) de las prácticas obtenidas con `getMisPracticasPendientesAceptacionAction`.
    * Cada práctica listada incluye información clave del alumno, carrera, sede y fechas, y un botón "Revisar y Decidir Acta 1".
* **Página "Revisar Acta 1" (`/docente/practicas-pendientes/[practicaId]/revisar-acta/page.tsx`):**
    * Página dinámica protegida que carga y muestra los detalles completos de una práctica específica.
    * Renderiza `RevisarActaDocenteCliente.tsx`.
* **Vista de Revisión y Decisión (`RevisarActaDocenteCliente.tsx`):**
    * Muestra toda la información del Acta 1 (partes del Coordinador y del Alumno) en formato de solo lectura, organizada en secciones claras.
    * Presenta los botones "Aceptar Supervisión" y "Rechazar Supervisión" si la práctica está en el estado `PENDIENTE_ACEPTACION_DOCENTE`.
    * Al hacer clic en "Aceptar Supervisión", se llama a `submitDecisionDocenteActaAction` con la decisión "ACEPTADA".
    * Al hacer clic en "Rechazar Supervisión", se abre el modal `RejectionReasonModal.tsx`.
* **Modal de Motivo de Rechazo (`RejectionReasonModal.tsx`):**
    * Nuevo componente de diálogo que permite al docente ingresar un motivo (texto) para el rechazo.
    * Utiliza React Hook Form y Zod (`rejectionSchema`) para la validación del motivo.
    * Al enviar el motivo, se llama a `submitDecisionDocenteActaAction` con la decisión "RECHAZADA" y el motivo proporcionado.
* **Experiencia de Usuario:**
    * Gestión de estados de carga (`isProcessing`) en los botones de decisión y en el modal de rechazo.
    * Feedback al usuario mediante notificaciones toast (Sonner) para confirmar la acción o reportar errores.
    * Actualización del estado de la práctica en la UI de la página de revisión y deshabilitación de los botones de acción después de una decisión.