### PR TITLE
feat(HU-29): Implementar subida de informes de práctica para alumnos

### DIFF
--- a/src/app/(main)/alumno/mis-practicas/mis-practicas-client.tsx
+++ b/src/app/(main)/alumno/mis-practicas/mis-practicas-client.tsx
@@ -12,7 +12,7 @@ import {
     CardTitle 
 } from '@/components/ui/card';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Edit3, Terminal, Info } from 'lucide-react';
+import { Edit3, Terminal, Info, FileText } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 
@@ -27,6 +27,17 @@ export function MisPracticasCliente({ initialActionResponse }: MisPracticasClien
   // El estado se inicializa con los datos pasados desde el Server Component
   const [practicas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
   const [error] = React.useState<string | null>(initialActionResponse.error || null);
+
+  //  efinir estados de práctica donde se puede subir informe
+  const puedeSubirInforme = (estado: PracticaConDetalles['estado']): boolean => {
+    return [
+      'EN_CURSO',
+      'INFORME_RECHAZADO', // Si el informe fue rechazado, puede subir uno nuevo
+      'EVALUADA_CON_PENDENCIAS', // Si fue evaluada con pendencias, podría necesitar subir correcciones
+      'APROBADA', // Permitir ver el informe aunque esté aprobada
+      'REPROBADA', // Permitir ver el informe aunque esté reprobada
+    ].includes(estado);
+  };
 
   if (error) {
     return (
@@ -73,13 +84,26 @@ export function MisPracticasCliente({ initialActionResponse }: MisPracticasClien
             <p><strong>Fecha de Término Estimada:</strong> {format(new Date(practica.fechaTermino), "PPP", { locale: es })}</p>
             <p><strong>Docente Tutor Asignado:</strong> {practica.docente?.usuario?.nombre || ''} {practica.docente?.usuario?.apellido || 'No asignado'}</p>
           </CardContent>
-          <CardFooter className="border-t pt-4">
-            <Button asChild size="sm" className="ml-auto">
-              <Link href={`/alumno/mis-practicas/${practica.id}/completar-acta`}>
-                <Edit3 className="mr-2 h-4 w-4" />
-                Completar Acta 1
-              </Link>
-            </Button>
+          <CardFooter className="border-t pt-4 flex justify-end space-x-2"> 
+            {/* BOTÓN COMPLETAR ACTA 1 (EXISTENTE) */}
+            {practica.estado === 'PENDIENTE' && (
+              <Button asChild size="sm" variant="outline">
+                <Link href={`/alumno/mis-practicas/${practica.id}/completar-acta`}>
+                  <Edit3 className="mr-2 h-4 w-4" />
+                  Completar Acta 1
+                </Link>
+              </Button>
+            )}
+            
+            {/* BOTÓN SUBIR/VER INFORME */}
+            {puedeSubirInforme(practica.estado) && (
+              <Button asChild size="sm">
+                <Link href={`/alumno/subir-informe?practicaId=${practica.id}`}>
+                  <FileText className="mr-2 h-4 w-4" />
+                  {practica.informeUrl ? 'Ver/Actualizar Informe' : 'Subir Informe Final'}
+                </Link>
+              </Button>
+            )}
           </CardFooter>
         </Card>
       ))}

--- a/src/app/(main)/alumno/subir-informe/page.tsx
+++ b/src/app/(main)/alumno/subir-informe/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from 'next/navigation';
+import { getUserSession } from '@/lib/auth';
+import type { RoleName } from '@/types/roles';
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { ActionResponse, getMisPracticasParaInformeAction } from '../practicas/actions';
+import { SubirInformeCliente } from './subir-informe-client';
+
+const REQUIRED_ROLE: RoleName = 'ALUMNO';
+
+export default async function SubirInformePage() {
+  const userPayload = await getUserSession();
+
+  if (!userPayload) {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const loginUrl = new URL('/login', baseUrl);
+    redirect(loginUrl.toString());
+  }
+
+  if (userPayload.rol !== REQUIRED_ROLE) {
+    console.warn(
+      `Acceso no autorizado a /alumno/subir-informe. Usuario RUT: ${userPayload.rut}, Rol: ${userPayload.rol}. Rol requerido: ${REQUIRED_ROLE}`
+    );
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
+    const dashboardUrl = new URL('/dashboard', baseUrl);
+    redirect(dashboardUrl.toString());
+  }
+
+  // Llama a la action para obtener las prácticas que pueden subir informe
+  const result: ActionResponse<PracticaConDetalles[]> = await getMisPracticasParaInformeAction();
+  
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Subir Informe de Práctica
+        </h1>
+        <p className="mt-2 text-lg text-gray-600 dark:text-gray-400">
+          Aquí puedes subir los informes de tus prácticas que estén en curso o finalizadas pendientes de evaluación.
+        </p>
+      </header>
+      <SubirInformeCliente initialActionResponse={result} />
+    </div>
+  );
+}

--- a/src/app/(main)/alumno/subir-informe/subir-informe-client.tsx
+++ b/src/app/(main)/alumno/subir-informe/subir-informe-client.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardFooter, 
+    CardHeader, 
+    CardTitle 
+} from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { 
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { 
+    Upload, 
+    Terminal, 
+    Info, 
+    FileText, 
+    CheckCircle, 
+    AlertCircle,
+    Trash2
+} from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { toast } from 'sonner';
+
+import type { PracticaConDetalles } from '@/lib/validators/practica';
+import { ActionResponse, subirInformePracticaAction } from '../practicas/actions';
+
+interface SubirInformeClienteProps {
+  initialActionResponse: ActionResponse<PracticaConDetalles[]>;
+}
+
+// Constantes para validación del informe
+const MAX_FILE_SIZE_KB_INFORME = 1024; // 1 MB
+const MAX_FILE_SIZE_BYTES_INFORME = MAX_FILE_SIZE_KB_INFORME * 1024;
+const ALLOWED_FILE_TYPES = ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'];
+const ALLOWED_EXTENSIONS = ['.pdf', '.doc', '.docx'];
+const ALLOWED_EXTENSIONS_STRING = ALLOWED_EXTENSIONS.join(', ');
+
+export function SubirInformeCliente({ initialActionResponse }: SubirInformeClienteProps) {
+  const router = useRouter();
+  const [practicas] = React.useState<PracticaConDetalles[]>(initialActionResponse.data || []);
+  const [error] = React.useState<string | null>(initialActionResponse.error || null);
+  
+  // Estados para el modal de subida
+  const [selectedPractica, setSelectedPractica] = React.useState<PracticaConDetalles | null>(null);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
+  const [fileError, setFileError] = React.useState<string | null>(null);
+  const [isUploading, setIsUploading] = React.useState(false);
+  
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFileError(null);
+    const file = event.target.files?.[0];
+    
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+
+    if (file) {
+      // Validar tipo de archivo
+      if (!ALLOWED_FILE_TYPES.includes(file.type)) {
+        const errorMsg = `Tipo de archivo no válido. Permitidos: ${ALLOWED_EXTENSIONS_STRING}.`;
+        toast.error(errorMsg);
+        setFileError(errorMsg);
+        setSelectedFile(null);
+        return;
+      }
+
+      // Validar tamaño del archivo
+      if (file.size > MAX_FILE_SIZE_BYTES_INFORME) {
+        const errorMsg = `El archivo excede ${MAX_FILE_SIZE_KB_INFORME} KB (1 MB). Actual: ${(file.size / 1024).toFixed(1)} KB`;
+        toast.error(errorMsg);
+        setFileError(errorMsg);
+        setSelectedFile(null);
+        return;
+      }
+
+      setSelectedFile(file);
+      toast.success(`Archivo "${file.name}" seleccionado correctamente.`);
+    }
+  };
+
+  const handleRemoveFile = () => {
+    setSelectedFile(null);
+    setFileError(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleUploadInforme = async () => {
+    if (!selectedFile || !selectedPractica) {
+      toast.error("Debe seleccionar un archivo para subir.");
+      return;
+    }
+
+    if (fileError) {
+      toast.error(fileError);
+      return;
+    }
+
+    setIsUploading(true);
+    const formData = new FormData();
+    formData.append("file", selectedFile);
+
+    try {
+      // Subir archivo al blob storage
+      const uploadResponse = await fetch('/api/upload/informe', {
+        method: 'POST',
+        body: formData,
+      });
+      
+      const uploadResult = await uploadResponse.json();
+
+      if (!uploadResponse.ok || !uploadResult.success || !uploadResult.url) {
+        toast.error(uploadResult.error || "Error al subir el archivo al almacenamiento.");
+        return;
+      }
+
+      const informeUrl: string = uploadResult.url;
+      toast.info("Archivo subido correctamente. Registrando en el sistema...");
+
+      // Registrar la URL del informe en la base de datos
+      const result: ActionResponse<PracticaConDetalles> = await subirInformePracticaAction(
+        selectedPractica.id, 
+        { informeUrl }
+      );
+
+      if (result.success && result.data) {
+        toast.success(result.message || "¡Informe subido exitosamente!");
+        setIsModalOpen(false);
+        setSelectedFile(null);
+        setSelectedPractica(null);
+        setFileError(null);
+        router.refresh(); // Recargar para mostrar el estado actualizado
+      } else {
+        toast.error(result.error || "Error al registrar el informe en el sistema.");
+        
+        // Intentar eliminar el archivo subido si falló el registro
+        try {
+          await fetch(`/api/upload/informe?url=${encodeURIComponent(informeUrl)}`, {
+            method: 'DELETE',
+          });
+        } catch (deleteError) {
+          console.error("Error al eliminar archivo tras fallo de registro:", deleteError);
+        }
+      }
+    } catch (error) {
+      console.error("Error en el proceso de subida de informe:", error);
+      toast.error("Error de conexión o inesperado al subir el informe.");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const openModal = (practica: PracticaConDetalles) => {
+    setSelectedPractica(practica);
+    setIsModalOpen(true);
+    setSelectedFile(null);
+    setFileError(null);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedPractica(null);
+    setSelectedFile(null);
+    setFileError(null);
+  };
+
+  if (error) {
+    return (
+      <Alert variant="destructive" className="max-w-2xl mx-auto">
+        <Terminal className="h-4 w-4" />
+        <AlertTitle>Error al Cargar Prácticas</AlertTitle>
+        <AlertDescription>{error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (practicas.length === 0) {
+    return (
+      <div className="text-center py-10 border-2 border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
+        <Info className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+        <h3 className="mt-2 text-lg font-medium text-gray-900 dark:text-white">
+          No tienes prácticas disponibles para subir informe
+        </h3>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Solo puedes subir informes de prácticas que estén en curso o finalizadas pendientes de evaluación.
+        </p>
+        <div className="mt-6">
+          <Button asChild variant="outline">
+            <Link href="/alumno/mis-practicas">
+              Ver Mis Prácticas
+            </Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-6">
+        {practicas.map((practica) => (
+          <Card key={practica.id} className="shadow-sm hover:shadow-md transition-shadow">
+            <CardHeader>
+              <CardTitle className="text-xl flex justify-between items-center">
+                <span>
+                  Práctica: {practica.tipo === 'LABORAL' ? 'Laboral' : 'Profesional'}
+                </span>
+                <div className="flex items-center gap-2">
+                  {practica.informeUrl ? (
+                    <span className="text-sm font-normal px-2 py-1 rounded-full bg-green-100 text-green-700 dark:bg-green-800/30 dark:text-green-300 flex items-center">
+                      <CheckCircle className="h-3 w-3 mr-1" />
+                      Informe Subido
+                    </span>
+                  ) : (
+                    <span className="text-sm font-normal px-2 py-1 rounded-full bg-orange-100 text-orange-700 dark:bg-orange-800/30 dark:text-orange-300 flex items-center">
+                      <AlertCircle className="h-3 w-3 mr-1" />
+                      Pendiente Informe
+                    </span>
+                  )}
+                  <span className={`text-sm font-normal px-2 py-1 rounded-full ${
+                    practica.estado === 'EN_CURSO' 
+                      ? 'bg-blue-100 text-blue-700 dark:bg-blue-800/30 dark:text-blue-300'
+                      : 'bg-purple-100 text-purple-700 dark:bg-purple-800/30 dark:text-purple-300'
+                  }`}>
+                    {practica.estado === 'EN_CURSO' ? 'En Curso' : 'Finalizada - Pendiente Eval.'}
+                  </span>
+                </div>
+              </CardTitle>
+              <CardDescription>
+                {practica.carrera?.nombre || 'Carrera no especificada'} - {practica.carrera?.sede?.nombre || 'N/A'}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-1 text-sm">
+              <p><strong>Fecha de Inicio:</strong> {format(new Date(practica.fechaInicio), "PPP", { locale: es })}</p>
+              <p><strong>Fecha de Término:</strong> {format(new Date(practica.fechaTermino), "PPP", { locale: es })}</p>
+              <p><strong>Docente Tutor:</strong> {practica.docente?.usuario?.nombre || ''} {practica.docente?.usuario?.apellido || 'No asignado'}</p>
+              {practica.informeUrl && (
+                <p><strong>Informe Actual:</strong> 
+                  <Button asChild variant="link" size="sm" className="p-0 h-auto ml-1">
+                    <a href={practica.informeUrl} target="_blank" rel="noopener noreferrer">
+                      <FileText className="h-3 w-3 mr-1" />
+                      Ver Documento
+                    </a>
+                  </Button>
+                </p>
+              )}
+            </CardContent>
+            <CardFooter className="border-t pt-4">
+              <Button 
+                onClick={() => openModal(practica)}
+                size="sm" 
+                className="ml-auto"
+                disabled={isUploading}
+              >
+                <Upload className="mr-2 h-4 w-4" />
+                {practica.informeUrl ? 'Actualizar Informe' : 'Subir Informe'}
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+
+      {/* Modal para subir informe */}
+      <Dialog open={isModalOpen} onOpenChange={closeModal}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {selectedPractica?.informeUrl ? 'Actualizar' : 'Subir'} Informe de Práctica
+            </DialogTitle>
+            <DialogDescription>
+              Selecciona un archivo PDF, DOC o DOCX (máximo 1 MB) para {selectedPractica?.informeUrl ? 'actualizar' : 'subir'} tu informe de práctica.
+            </DialogDescription>
+          </DialogHeader>
+          
+          <div className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <input
+                type="file"
+                ref={fileInputRef}
+                className="hidden"
+                accept={ALLOWED_FILE_TYPES.join(",")}
+                onChange={handleFileChange}
+                disabled={isUploading}
+              />
+              
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isUploading}
+                className="w-full"
+              >
+                <Upload className="mr-2 h-4 w-4" />
+                {selectedFile ? "Cambiar Archivo" : "Seleccionar Archivo"}
+              </Button>
+              
+              {selectedFile && (
+                <div className="flex items-center justify-between p-2 bg-muted rounded-md">
+                  <div className="flex items-center gap-2">
+                    <FileText className="h-4 w-4" />
+                    <span className="text-sm font-medium">{selectedFile.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      ({(selectedFile.size / 1024).toFixed(1)} KB)
+                    </span>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleRemoveFile}
+                    disabled={isUploading}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+              
+              {fileError && (
+                <p className="text-sm text-destructive">{fileError}</p>
+              )}
+              
+              <p className="text-xs text-muted-foreground">
+                Formatos permitidos: {ALLOWED_EXTENSIONS_STRING}. Tamaño máximo: {MAX_FILE_SIZE_KB_INFORME} KB (1 MB).
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeModal}
+              disabled={isUploading}
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              onClick={handleUploadInforme}
+              disabled={!selectedFile || !!fileError || isUploading}
+            >
+              <Upload className="mr-2 h-4 w-4" />
+              {isUploading ? "Subiendo..." : (selectedPractica?.informeUrl ? 'Actualizar' : 'Subir') + ' Informe'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/api/upload/informe/route.ts
+++ b/src/app/api/upload/informe/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { put, del } from '@vercel/blob';
+import { nanoid } from 'nanoid';
+
+// Constantes para validación del informe de práctica
+const MAX_FILE_SIZE_KB_INFORME = 1024; // 1 MB = 1024 KB
+const MAX_FILE_SIZE_BYTES_INFORME = MAX_FILE_SIZE_KB_INFORME * 1024;
+const ALLOWED_CONTENT_TYPES_INFORME = [
+  'application/pdf',
+  'application/msword', // .doc
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document' // .docx
+];
+const UPLOAD_SUBFOLDER_INFORME = 'informes-practica';
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No se recibió ningún archivo.' }, { status: 400 });
+    }
+
+    // Validar tipo de contenido
+    if (!ALLOWED_CONTENT_TYPES_INFORME.includes(file.type)) {
+      return NextResponse.json(
+        { error: `Tipo de archivo no permitido. Permitidos: PDF, DOC, DOCX. Recibido: ${file.type}` },
+        { status: 400 }
+      );
+    }
+
+    // Validar tamaño del archivo
+    if (file.size > MAX_FILE_SIZE_BYTES_INFORME) {
+      return NextResponse.json(
+        { error: `El archivo excede el tamaño máximo de ${MAX_FILE_SIZE_KB_INFORME} KB (1 MB).` },
+        { status: 400 }
+      );
+    }
+
+    // Generar un nombre de archivo único para evitar colisiones y mantener la extensión original
+    const fileExtension = file.name.split('.').pop()?.toLowerCase() || 'unknown';
+    const uniqueFilename = `${UPLOAD_SUBFOLDER_INFORME}/${nanoid()}.${fileExtension}`;
+
+    const blob = await put(uniqueFilename, file, {
+      access: 'public',
+      contentType: file.type, 
+    });
+
+    // Devolver la URL pública del blob
+    return NextResponse.json({ 
+      success: true, 
+      url: blob.url, 
+      filename: file.name,
+      size: file.size 
+    }, { status: 200 });
+
+  } catch (error) {
+    console.error('Error al subir el informe:', error);
+    const errorMessage = error instanceof Error ? error.message : 'Error desconocido.';
+    return NextResponse.json(
+        { error: `Error interno del servidor al subir el informe: ${errorMessage}` }, 
+        { status: 500 }
+    );
+  }
+}
+
+// Manejo de eliminación de archivos subidos
+export async function DELETE(request: Request): Promise<NextResponse> {
+  try {
+    const { searchParams } = new URL(request.url);
+    const urlToDelete = searchParams.get('url');
+    if (!urlToDelete) {
+      return NextResponse.json({ error: 'URL del blob no proporcionada.' }, { status: 400 });
+    }
+    await del(urlToDelete);
+    return NextResponse.json({ success: true, message: 'Informe eliminado.' });
+
+  } catch (error) {
+    console.error('Error al eliminar el informe:', error);
+    return NextResponse.json({ error: 'Error interno al eliminar el informe.' }, { status: 500 });
+  }
+}

--- a/src/lib/services/practicaService.ts
+++ b/src/lib/services/practicaService.ts
@@ -8,8 +8,9 @@ import {
     type IniciarPracticaInput, 
     type CompletarActaAlumnoData, 
     type EditarPracticaCoordDCInput,
-    DecisionDocenteActaData
-} from '@/lib/validators/practica'; 
+    DecisionDocenteActaData,
+    type SubirInformePracticaData
+} from '@/lib/validators/practica';
 import { isHoliday } from './holidayService';
 
 const HORAS_POR_DIA_LABORAL = 8;
@@ -533,6 +534,83 @@ export class PracticaService {
     } catch (error) {
       console.error('Error al obtener prácticas para gestión:', error);
       return { success: false, error: 'No se pudieron obtener las prácticas para gestión.' };
+    }
+  }
+
+  /**
+   * Permite a un alumno subir su informe de práctica.
+   * Valida que la práctica esté en estado apropiado y actualiza la URL del informe.
+   */
+  static async subirInformePractica(
+    practicaId: number,
+    alumnoUsuarioId: number,
+    informeUrl: string
+  ) {
+    try {
+      const alumno = await prisma.alumno.findUnique({
+        where: { usuarioId: alumnoUsuarioId },
+        select: { id: true }
+      });
+
+      if (!alumno) {
+        return { success: false, error: "Perfil de alumno no encontrado." };
+      }
+
+      const practica = await prisma.practica.findUnique({
+        where: { id: practicaId },
+        select: { 
+          id: true, 
+          alumnoId: true, 
+          estado: true, 
+          fechaTermino: true,
+          informeUrl: true 
+        }
+      });
+
+      if (!practica) {
+        return { success: false, error: 'Práctica no encontrada.' };
+      }
+
+      if (practica.alumnoId !== alumno.id) {
+        return { success: false, error: 'No tienes permiso para subir el informe de esta práctica.' };
+      }      // Verificar que la práctica esté en un estado válido para subir informe
+      if (practica.estado !== PrismaEstadoPracticaEnum.EN_CURSO && 
+          practica.estado !== PrismaEstadoPracticaEnum.FINALIZADA_PENDIENTE_EVAL) {
+        return { 
+          success: false, 
+          error: `No puedes subir el informe en el estado actual: ${practica.estado}. La práctica debe estar en curso o finalizada pendiente de evaluación.` 
+        };
+      }
+
+      // Validar que la fecha de término haya pasado para permitir la subida
+      const hoy = new Date();
+      const fechaTermino = new Date(practica.fechaTermino);
+      
+      if (hoy < fechaTermino) {
+        return { 
+          success: false, 
+          error: 'No puedes subir el informe antes de la fecha de término de la práctica.' 
+        };
+      }      const updatedPractica = await prisma.practica.update({
+        where: { id: practicaId },
+        data: {
+          informeUrl: informeUrl,
+          // Si es la primera vez que sube el informe y está en curso, cambiar estado
+          ...(practica.estado === PrismaEstadoPracticaEnum.EN_CURSO && !practica.informeUrl && {
+            estado: PrismaEstadoPracticaEnum.FINALIZADA_PENDIENTE_EVAL
+          })
+        },
+        include: {
+          alumno: { include: { usuario: true, carrera: { include: { sede: true } } } },
+          docente: { include: { usuario: true } },
+          carrera: { include: { sede: true } },
+        }
+      });
+
+      return { success: true, data: updatedPractica };
+    } catch (error) {
+      console.error("Error al subir informe de práctica:", error);
+      return { success: false, error: 'No se pudo subir el informe de práctica.' };
     }
   }
 }

--- a/src/lib/services/practicaService.ts
+++ b/src/lib/services/practicaService.ts
@@ -8,8 +8,7 @@ import {
     type IniciarPracticaInput, 
     type CompletarActaAlumnoData, 
     type EditarPracticaCoordDCInput,
-    DecisionDocenteActaData,
-    type SubirInformePracticaData
+    DecisionDocenteActaData
 } from '@/lib/validators/practica';
 import { isHoliday } from './holidayService';
 

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -82,6 +82,16 @@ export const decisionDocenteActaSchema = z.object({
 
 export type DecisionDocenteActaData = z.infer<typeof decisionDocenteActaSchema>;
 
+// Schema para subir informe de práctica
+export const subirInformePracticaSchema = z.object({
+  informeUrl: z.string({
+    required_error: "La URL del informe es requerida.",
+  }).url("Debe ser una URL válida del informe subido."),
+});
+
+export type SubirInformePracticaData = z.infer<typeof subirInformePracticaSchema>;
+
+// Schema para editar práctica por el Coordinador o Docente de Carrera
 export const editarPracticaCoordDCSchema = z.object({
   docenteId: z.coerce.number({
     invalid_type_error: "ID de docente inválido.",

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -213,12 +213,11 @@ export interface PracticaConDetalles {
   contactoCorreoJefe?: string | null;  
   contactoTelefonoJefe?: string | null;
   practicaDistancia?: boolean | null;
-  tareasPrincipales?: string | null;
-  fechaCompletadoAlumno?: Date | null;
+  tareasPrincipales?: string | null;  fechaCompletadoAlumno?: Date | null;
   motivoRechazoDocente?: string | null;
+  informeUrl?: string | null; // URL del informe de práctica subido por el alumno
 
-
-  // DATOS RELACIONALES 
+  // DATOS RELACIONALES
   alumno?: { // Datos del alumno asociado
     id: number; 
     usuario: { 


### PR DESCRIPTION
Este Pull Request introduce la funcionalidad completa para que los alumnos puedan subir sus informes finales de práctica, correspondiente a la Historia de Usuario HU-29.

**Cambios Principales:**

**Backend y Lógica:**
*   **API Endpoint (`/api/upload/informe/route.ts`):**
    *   Se ha creado un nuevo endpoint para gestionar la subida de archivos de informes.
    *   Valida el tipo de archivo (PDF, DOC, DOCX) y el tamaño máximo (1MB).
    *   Almacena el archivo y gestiona la URL resultante para ser guardada en la base de datos.
*   **Validadores (`src/lib/validators/practica.ts`):**
    *   Se añadió el schema `subirInformePracticaSchema` para validar los datos relacionados con la subida del informe.
    *   Se actualizó la interfaz `PracticaConDetalles` para incluir el campo `informeUrl`, permitiendo el acceso a la URL del informe en los componentes de UI.
*   **Servicios (`src/lib/services/practicaService.ts`):**
    *   Se mejoró el método `subirInformePractica` para procesar la URL del informe y actualizar el campo `informeUrl` y `fechaSubidaInforme` en la entidad `Practica`.
*   **Acciones de Servidor (`src/app/(main)/alumno/practicas/actions.ts`):**
    *   Se implementó `subirInformeAction` para conectar la interfaz de usuario con los servicios del backend, facilitando la subida del informe.

**Frontend:**
*   **Páginas de Subida de Informe:**
    *   Se crearon los componentes `src/app/(main)/alumno/subir-informe/page.tsx` (componente de servidor) y `src/app/(main)/alumno/subir-informe/subir-informe-client.tsx` (componente de cliente).
    *   La interfaz de usuario permite al alumno seleccionar un archivo, muestra el informe actual si ya existe uno, y gestiona el proceso de subida o actualización del informe.
    *   Incluye manejo de estados de carga y retroalimentación visual al usuario mediante `toasts` para operaciones exitosas o erróneas.
*   **Integración con "Mis Prácticas" (`src/app/(main)/alumno/mis-practicas/mis-practicas-client.tsx`):**
    *   Se ha añadido un botón en cada tarjeta de práctica dentro de la vista "Mis Prácticas" del alumno.
    *   El texto del botón es dinámico ("Subir Informe Final" o "Ver/Actualizar Informe") dependiendo de si ya existe un informe subido y del estado actual de la práctica.
    *   El botón redirige al alumno a la página de subida de informe, pasando el ID de la práctica correspondiente como parámetro en la URL (`/alumno/subir-informe?practicaId=[id]`).
    *   La visibilidad del botón está condicionada por estados de práctica relevantes (ej. `EN_CURSO`, `INFORME_RECHAZADO`, `APROBADA`, `EVALUADA_CON_PENDENCIAS`, etc.), permitiendo la subida o visualización según corresponda.

**Correcciones Realizadas:**
*   Se solucionaron errores de importación que afectaban a los componentes de la página de subida de informes.
*   Se corrigieron errores de TypeScript derivados de la ausencia inicial del campo `informeUrl` en la interfaz `PracticaConDetalles`.
*   Se eliminó una importación no utilizada (`SubirInformePracticaData`) del archivo `practicaService.ts` para mejorar la limpieza del código.

**Pendiente (Criterio de HU-29 a ser tratado en HU-48):**
*   La acción de subir el informe dispara la notificación al docente. (Este punto se abordará en la HU-48, según lo especificado en los criterios de aceptación).