### PR TITLE
HU-31: Permitir a Docentes Descargar Informes de Práctica

### DIFF
--- a/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
+++ b/src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import React from 'react';
-import { useRouter } from 'next/navigation'; // <--- CAMBIO AQUÍ
+import { useRouter } from 'next/navigation'; 
 import { Button } from '@/components/ui/button';
 import { 
     Card, 
@@ -12,7 +12,7 @@ import {
     CardTitle 
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, ClipboardList } from 'lucide-react';
+import { CheckCircle, XCircle, ExternalLink, Building, User, Settings, ClipboardList, Download, FileText } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import type { PracticaConDetalles, DecisionDocenteActaData } from '@/lib/validators/practica';
@@ -181,6 +181,35 @@ export function RevisarActaDocenteCliente({ practica: initialPractica }: Revisar
                 <InfoItem label="" value={practica.tareasPrincipales} isList />
             </div>
           </div>
+
+          {/* Sección Informe de Práctica */}
+          {practica.informeUrl && (
+            <div className="mt-6 pt-6 border-t">
+              <h3 className="text-md font-semibold text-gray-500 dark:text-gray-400 mb-3 flex items-center">
+                <FileText className="mr-2 h-5 w-5"/>Informe Final de Práctica
+              </h3>
+              <dl className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6">
+                <div> {/* Envuelve el botón en un div o usa InfoItem si prefieres consistencia */}
+                  <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Archivo Subido</dt>
+                  <dd className="mt-1">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => window.open(practica.informeUrl!, '_blank')}
+                      className="w-full sm:w-auto"
+                    >
+                      <Download className="mr-2 h-4 w-4" />
+                      Descargar Informe
+                    </Button>
+                  </dd>
+                </div>
+                {practica.fechaSubidaInforme && (
+                   <InfoItem label="Fecha de Subida" value={practica.fechaSubidaInforme} isDate />
+                )}
+              </dl>
+            </div>
+          )}
+          {/* Sección Informe de Práctica */}
         </CardContent>
       </Card>
 

--- a/src/lib/validators/practica.ts
+++ b/src/lib/validators/practica.ts
@@ -216,6 +216,7 @@ export interface PracticaConDetalles {
   tareasPrincipales?: string | null;  fechaCompletadoAlumno?: Date | null;
   motivoRechazoDocente?: string | null;
   informeUrl?: string | null; // URL del informe de práctica subido por el alumno
+  fechaSubidaInforme?: Date | null; // Fecha en que se subió el informe
 
   // DATOS RELACIONALES
   alumno?: { // Datos del alumno asociado


### PR DESCRIPTION
Este Pull Request implementa la Historia de Usuario HU-31, permitiendo a los docentes asignados acceder y descargar los informes de práctica subidos por sus alumnos. Esto facilita el proceso de revisión y evaluación de dichos informes.

**Cambios Implementados:**

*   **Modificación de la Vista de Revisión del Docente (`src/app/(main)/docente/practicas-pendientes/[practicaId]/revisar-acta/revisar-acta-docente-client.tsx`):**
    *   Se ha añadido una nueva sección titulada "Informe Final de Práctica" dentro de la tarjeta de detalles de la práctica.
    *   Esta sección es visible solo si el alumno ha subido un informe (es decir, si `practica.informeUrl` tiene un valor).
    *   Dentro de esta sección, se muestra:
        *   Un botón con el texto "Descargar Informe" y un icono de descarga. Al hacer clic, este botón abre la URL del informe (`practica.informeUrl`) en una nueva pestaña del navegador, lo que típicamente inicia la descarga del archivo o lo muestra si el navegador soporta la previsualización del tipo de archivo (PDF/Word).
        *   La fecha en que el informe fue subido por el alumno (`practica.fechaSubidaInforme`), si esta información está disponible.
    *   Se importaron los iconos `Download` y `FileText` de `lucide-react` para mejorar la interfaz visual.

*   **Actualización de la Interfaz de Datos (`src/lib/validators/practica.ts`):**
    *   Se ha modificado la interfaz `PracticaConDetalles` para incluir el campo opcional `fechaSubidaInforme?: Date | null;`.
    *   Este cambio era necesario para que el componente cliente pudiera acceder a la fecha de subida del informe y mostrarla, resolviendo así errores de TypeScript que surgieron al intentar acceder a un campo no definido previamente en la interfaz.
